### PR TITLE
feat: add support for Trivy as an SBOM cataloger

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -57,7 +57,7 @@ func init() {
 	generateCmd.Flags().StringVarP(&documentVersion, "version", "v", "0.0.1", "Version for the SBOM document")
 	generateCmd.Flags().StringSliceVar(&authors, "author", []string{}, "Document authors (can be specified multiple times)")
 	generateCmd.Flags().StringSliceVar(&attestationTypes, "types", []string{"material", "command-run", "product", "network-trace"}, "Attestation types to parse (comma-separated).")
-	generateCmd.Flags().StringVarP(&catalog, "catalog", "c", "", "Cataloger to run before processing attestations (supported: syft)")
+	generateCmd.Flags().StringVarP(&catalog, "catalog", "c", "", "Cataloger to run before processing attestations (supported: syft, trivy)")
 	generateCmd.Flags().StringVar(&projectDir, "project-dir", "", "Project directory to scan with the cataloger (default: current directory)")
 }
 
@@ -75,10 +75,10 @@ func runGenerate(attestationFile string) error {
 	}
 
 	validCatalogs := map[string]bool{
-		"": true, "syft": true,
+		"": true, "syft": true, "trivy": true,
 	}
 	if !validCatalogs[strings.ToLower(catalog)] {
-		return fmt.Errorf("invalid catalog: %s (supported: syft)", catalog)
+		return fmt.Errorf("invalid catalog: %s (supported: syft, trivy)", catalog)
 	}
 
 	opts := &generator.Options{

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -385,7 +385,7 @@ func (g *Generator) runSyft(projectDir string) (*sbom.Document, error) {
 
 func (g *Generator) runTrivy(projectDir string) (*sbom.Document, error) {
 	if _, err := exec.LookPath("trivy"); err != nil {
-		return nil, fmt.Errorf("trivy not found in PATH. Install options:\n  - macOS (brew): brew install aquasecurity/trivy/trivy\n  - other platforms: https://aquasecurity.github.io/trivy/latest/getting-started/installation/")
+		return nil, fmt.Errorf("trivy not found in PATH. Install options:\n  - macOS (brew): brew install trivy\n  - other platforms: https://trivy.dev/docs/latest/getting-started/installation/")
 	}
 
 	tmpFile, err := os.CreateTemp("", "sbomit-trivy-*.json")

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -111,6 +111,11 @@ func (g *Generator) GenerateFromAttestations(attestations []attestation.TypedAtt
 		if err != nil {
 			return fmt.Errorf("failed to run syft: %w", err)
 		}
+	case "trivy":
+		baseDoc, err = g.runTrivy(projectDir)
+		if err != nil {
+			return fmt.Errorf("failed to run trivy: %w", err)
+		}
 	default:
 	}
 
@@ -374,6 +379,31 @@ func (g *Generator) runSyft(projectDir string) (*sbom.Document, error) {
 		return nil, fmt.Errorf("close syft output: %w", err)
 	}
 
+	r := reader.New()
+	return r.ParseFile(tmpFile.Name())
+}
+
+func (g *Generator) runTrivy(projectDir string) (*sbom.Document, error) {
+	if _, err := exec.LookPath("trivy"); err != nil {
+		return nil, fmt.Errorf("trivy not found in PATH. Install options:\n  - macOS (brew): brew install aquasecurity/trivy/trivy\n  - other platforms: https://aquasecurity.github.io/trivy/latest/getting-started/installation/")
+	}
+
+	tmpFile, err := os.CreateTemp("", "sbomit-trivy-*.json")
+	if err != nil {
+		return nil, fmt.Errorf("create temp file: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	var stderr bytes.Buffer
+	// Tell Trivy to scan the directory and output an SPDX JSON file
+	cmd := exec.Command("trivy", "fs", "--format", "spdx-json", "--output", tmpFile.Name(), projectDir)
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("trivy failed: %w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+
+	// Parse the SBOM using protobom (the same way we do with Syft)
 	r := reader.New()
 	return r.ParseFile(tmpFile.Name())
 }


### PR DESCRIPTION
### Description

The `sbomit generate` command currently only supports Anchore's `syft` plugin to generate a baseline SBOM document via the `--catalog` flag before resolving materials and network attestations. This pull request extends that functionality to natively support `trivy` as an alternative cataloger.

### Fixes #10

---

### Changes Made

*   **[cmd/generate.go](https://github.com/SBOMit/sbomit/blob/master/cmd/generate.go)**:
    *   Added `trivy` to the `validCatalogs` map layout.
    *   Updated the CLI help text string to document Trivy support.
*   **[pkg/generator/generator.go](https://github.com/SBOMit/sbomit/blob/master/pkg/generator/generator.go)**:
    *   Implemented the `runTrivy` orchestrator method to execute the Trivy CLI.
    *   Generates the base document via `trivy fs --format spdx-json` and loads it into the `protobom` reader for accurate aggregation.
    *   Updated the switch statement to accurately route `--catalog trivy` requests.

---

### Testing

**Before:**
Running `sbomit generate my-attestation.json --catalog trivy` failed immediately with:
<img width="1130" height="76" alt="Screenshot from 2026-04-02 14-41-52" src="https://github.com/user-attachments/assets/32a27276-6fdd-47ee-9053-13e23fc171bc" />


**After:**
*   Verified `sbomit generate <attestation-file> --catalog trivy` properly executes the local `trivy` binary, grabs the output file, and merges it natively with the resolver results.
*   Verified fallback error catching if `trivy` is not installed on the user's `$PATH`.
<img width="1125" height="51" alt="Screenshot from 2026-04-02 14-50-46" src="https://github.com/user-attachments/assets/1c3a9427-07cd-46c7-b461-8379a38194ae" />
