### PR TITLE
docs: add network-trace to README defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Flags:
   -v, --version string       Version for the SBOM document (default "0.0.1")
 ```
 
-By default, `sbomit` parses `material`, `command-run`, and `product` attestations. To restrict parsing on demand:
+By default, `sbomit` parses `material`, `command-run`, `product`, and `network-trace` attestations. To restrict parsing on demand:
 
 ```bash
 sbomit generate attestation.json --types command-run


### PR DESCRIPTION
## Summary

This PR updates the README to match the current CLI default attestation types.

## Changes

- added `network-trace` to the documented default attestation types

## Context

The CLI default includes `network-trace` in `--types`:

- [cmd/generate.go#L59](https://github.com/SBOMit/sbomit/blob/master/cmd/generate.go#L59)

The README previously documented only `material`, `command-run`, and `product`:

- [README.md#L37](https://github.com/SBOMit/sbomit/blob/master/README.md#L37)

resolves issue #28 
