### PR TITLE
fix: use dynamic versioning for sbomit generator tool

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,8 +2,12 @@ package main
 
 import (
 	"github.com/sbomit/sbomit/cmd"
+	"github.com/sbomit/sbomit/pkg/generator"
 )
 
+var Version = "0.0.1"
+
 func main() {
+	generator.Version = Version
 	cmd.Execute()
 }

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -20,6 +20,8 @@ import (
 	"github.com/sbomit/sbomit/pkg/resolver/network"
 )
 
+var Version = "0.0.1"
+
 type Options struct {
 	DocumentName     string
 	DocumentVersion  string
@@ -231,7 +233,7 @@ func (g *Generator) createDocument(result resolver.ResolverResult) *sbom.Documen
 
 	doc.Metadata.Tools = append(doc.Metadata.Tools, &sbom.Tool{
 		Name:    "sbomit",
-		Version: "0.0.1",
+		Version: Version,
 		Vendor:  "SBOMit",
 	})
 
@@ -282,7 +284,7 @@ func (g *Generator) applyMetadata(doc *sbom.Document) {
 
 	doc.Metadata.Tools = append(doc.Metadata.Tools, &sbom.Tool{
 		Name:    "sbomit",
-		Version: "0.0.1",
+		Version: Version,
 		Vendor:  "SBOMit",
 	})
 }


### PR DESCRIPTION

## Description

### Fixes #33 

This PR addresses an issue where the `sbomit` generator tool version was hardcoded to `"0.0.1"` within the generated SBOM metadata (`doc.Metadata.Tools`). Because of this hardcoding, the tool version remains static and prevents accurate artifact tagging during actual releases (e.g., v1.0.0, v1.1.0).

### Changes Made:
*   generator.go: Replaced the hardcoded `"0.0.1"` string in the `sbom.Tool` metadata generation logic (inside `createDocument` and `applyMetadata`) with an exported package level `Version` variable. 
*   main.go: Declared a top level `Version` variable and assigned it to `generator.Version` prior to CLI execution. This allows the tool version to be injected seamlessly during the build process using Go linker flags (for ex: `-ldflags "-X main.Version=..."`).

## How Has This Been Tested?

I verified this works as expected by locally compiling with a spoofed version via `ldflags`, and generating an SBOM against a sample attestation.

**Reproduction Steps:**
1. Build the binary with a custom version injected:
   ```bash
   go build -ldflags "-X main.Version=v1.2.3" -o sbomit main.go
   ```
2. Generate an SBOM from a sample witness attestation:
   ```bash
   ./sbomit generate test/sample-attestation.json -o sbom.json
   ```
3. Inspect sbom.json to verify the `version` field for the `sbomit` tool reports `v1.2.3` instead of `0.0.1`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have signed off all my commits (DCO).
- [x] I have verified the changes locally through build, execution, and output inspection.