### PR TITLE
Address OOM risk in witness parsing

### DIFF
--- a/pkg/attestation/parser.go
+++ b/pkg/attestation/parser.go
@@ -1,51 +1,59 @@
 package attestation
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 )
 
 func ParseWitnessFile(path string, typeFilter []string) ([]TypedAttestation, error) {
-	data, err := os.ReadFile(path)
+	file, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read witness file: %w", err)
 	}
+	defer file.Close()
 
-	return ParseWitnessData(data, typeFilter)
+	return parseWitnessReader(file, typeFilter)
 }
 
 func ParseWitnessData(data []byte, typeFilter []string) ([]TypedAttestation, error) {
+	return parseWitnessReader(bytes.NewReader(data), typeFilter)
+}
+
+func parseWitnessReader(r io.Reader, typeFilter []string) ([]TypedAttestation, error) {
+	decoder := json.NewDecoder(r)
+
 	var topLevel map[string]json.RawMessage
-	if err := json.Unmarshal(data, &topLevel); err != nil {
+	if err := decoder.Decode(&topLevel); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal attestation JSON: %w", err)
 	}
 
-	// Some witness outputs are direct in-toto statements (not DSSE envelopes).
-	if _, hasPredicate := topLevel["predicate"]; hasPredicate {
-		var statement InTotoStatement
-		if err := json.Unmarshal(data, &statement); err != nil {
+	var trailing json.RawMessage
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("failed to unmarshal attestation JSON: unexpected trailing JSON value")
+		}
+		return nil, fmt.Errorf("failed to unmarshal attestation JSON: %w", err)
+	}
+
+	if rawPredicate, hasPredicate := topLevel["predicate"]; hasPredicate {
+		var predicate map[string]interface{}
+		if err := json.Unmarshal(rawPredicate, &predicate); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal in-toto statement: %w", err)
 		}
-		return extractAttestations(statement.Predicate, typeFilter)
+		return extractAttestations(predicate, typeFilter)
 	}
 
-	var rawEnvelope struct {
-		PayloadType string          `json:"payloadType"`
-		Payload     json.RawMessage `json:"payload"`
-		Signatures  []Signature     `json:"signatures"`
-	}
-	if err := json.Unmarshal(data, &rawEnvelope); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal DSSE envelope: %w", err)
-	}
-
-	if len(rawEnvelope.Payload) == 0 {
+	rawPayload, hasPayload := topLevel["payload"]
+	if !hasPayload || len(rawPayload) == 0 {
 		return nil, fmt.Errorf("missing payload in attestation JSON (expected direct in-toto statement or DSSE envelope)")
 	}
 
-	payload, err := decodeEnvelopePayload(rawEnvelope.Payload)
+	payload, err := decodeEnvelopePayload(rawPayload)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode DSSE payload: %w", err)
 	}


### PR DESCRIPTION
Refers #41 
This pull request refactors the way witness files and data are parsed in the `pkg/attestation/parser.go` file. The main improvement is the introduction of a unified parsing function that works with any `io.Reader`, which simplifies handling both files and in-memory data. The code now also checks for trailing JSON and improves error handling for malformed input.

**Refactoring and improved parsing logic:**

* Introduced a new `parseWitnessReader` function that parses attestation data from any `io.Reader`, allowing both file-based and in-memory parsing to share the same logic. (`pkg/attestation/parser.go`)
* Updated `ParseWitnessFile` and `ParseWitnessData` to use the new `parseWitnessReader` function, reducing code duplication and improving maintainability. (`pkg/attestation/parser.go`)

**Robustness and error handling:**

* Added a check for trailing JSON after the main attestation object, returning an error if extra data is found, which helps catch malformed input files. (`pkg/attestation/parser.go`)
* Improved error messages and handling for missing or malformed payloads and predicates in the attestation JSON. (`pkg/attestation/parser.go`)