### PR TITLE
fix: data loss during network package deduplication

### DIFF
--- a/pkg/resolver/network/network.go
+++ b/pkg/resolver/network/network.go
@@ -57,7 +57,7 @@ func NewChain() *Chain {
 
 // ResolveAll resolves all connections, deduplicating by PURL.
 func (c *Chain) ResolveAll(conns []NetworkConnection) []resolver.PackageInfo {
-	seen := make(map[string]struct{})
+	seen := make(map[string]int)
 	var packages []resolver.PackageInfo
 	for _, conn := range conns {
 		dr, ok := c.byDomain[conn.Hostname]
@@ -68,10 +68,29 @@ func (c *Chain) ResolveAll(conns []NetworkConnection) []resolver.PackageInfo {
 			if pkg.PURL == "" {
 				continue
 			}
-			if _, already := seen[pkg.PURL]; already {
+			if idx, already := seen[pkg.PURL]; already {
+				if packages[idx].DownloadURL == "" && pkg.DownloadURL != "" {
+					packages[idx].DownloadURL = pkg.DownloadURL
+				}
+				if packages[idx].DownloadIP == "" && pkg.DownloadIP != "" {
+					packages[idx].DownloadIP = pkg.DownloadIP
+				}
+				if len(packages[idx].Licenses) == 0 && len(pkg.Licenses) > 0 {
+					packages[idx].Licenses = pkg.Licenses
+				}
+				if len(pkg.Hashes) > 0 {
+					if packages[idx].Hashes == nil {
+						packages[idx].Hashes = make(map[string]string)
+					}
+					for k, v := range pkg.Hashes {
+						if _, ok := packages[idx].Hashes[k]; !ok {
+							packages[idx].Hashes[k] = v
+						}
+					}
+				}
 				continue
 			}
-			seen[pkg.PURL] = struct{}{}
+			seen[pkg.PURL] = len(packages)
 			packages = append(packages, pkg)
 		}
 	}


### PR DESCRIPTION
## Description
Fixes #40

Network package deduplication in `pkg/resolver/network/network.go` was previously using a "first-wins" logic (`map[string]struct{}`). If a lightweight metadata trace was processed before a richer archive trace, later fields (like `Hashes` or `DownloadURL`) were being lost.

This PR replaces the deduplication method with a merge logic by mapping the PURL to the index in the original array. When duplicate PURLs are found, it intelligently merges missing metadata (e.g., `DownloadURL`, `DownloadIP`, `Licenses`, and `Hashes`) into the existing package entry.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings