### PR TITLE
Feature/package discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,7 @@ Contributions are welcome.
 ## Contact  
    
 For any inquiries or issues, please open an issue on the [Sbomit GitHub repository](https://github.com/sbomit/sbomit/issues).
+
+
+
+

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -18,6 +18,12 @@ var (
 	attestationTypes []string
 	catalog          string
 	projectDir       string
+    showPackages    bool
+    showPackageNames []string
+    showPackageSPDX bool
+    packagesOnly    bool
+
+
 )
 
 var generateCmd = &cobra.Command{
@@ -59,6 +65,11 @@ func init() {
 	generateCmd.Flags().StringSliceVar(&attestationTypes, "types", []string{"material", "command-run", "product", "network-trace"}, "Attestation types to parse (comma-separated).")
 	generateCmd.Flags().StringVarP(&catalog, "catalog", "c", "", "Cataloger to run before processing attestations (supported: syft, trivy)")
 	generateCmd.Flags().StringVar(&projectDir, "project-dir", "", "Project directory to scan with the cataloger (default: current directory)")
+
+	generateCmd.Flags().BoolVar(&showPackages, "show-packages", false, "Show all discovered packages")
+	generateCmd.Flags().StringSliceVar(&showPackageNames, "show-package", []string{}, "Show selected package(s), comma-separated")
+	generateCmd.Flags().BoolVar(&showPackageSPDX, "show-package-spdx", false, "Show SPDX-style JSON for selected package(s)")
+	generateCmd.Flags().BoolVar(&packagesOnly, "packages-only", false, "Only show package discovery output and skip SBOM output")
 }
 
 func runGenerate(attestationFile string) error {
@@ -90,6 +101,12 @@ func runGenerate(attestationFile string) error {
 		OutputPath:       outputPath,
 		Catalog:          catalog,
 		ProjectDir:       projectDir,
+
+
+		ShowPackages:     showPackages,
+		ShowPackageNames: showPackageNames,
+		ShowPackageSPDX:  showPackageSPDX,
+		PackagesOnly:     packagesOnly,
 	}
 
 	gen := generator.New(opts)

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -18,12 +18,10 @@ var (
 	attestationTypes []string
 	catalog          string
 	projectDir       string
-    showPackages    bool
-    showPackageNames []string
-    showPackageSPDX bool
-    packagesOnly    bool
-
-
+	showPackages     bool
+	showPackageNames []string
+	showPackageSPDX  bool
+	packagesOnly     bool
 )
 
 var generateCmd = &cobra.Command{
@@ -102,7 +100,6 @@ func runGenerate(attestationFile string) error {
 		OutputPath:       outputPath,
 		Catalog:          catalog,
 		ProjectDir:       projectDir,
-
 
 		ShowPackages:     showPackages,
 		ShowPackageNames: showPackageNames,

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -68,7 +68,8 @@ func init() {
 
 	generateCmd.Flags().BoolVar(&showPackages, "show-packages", false, "Show all discovered packages")
 	generateCmd.Flags().StringSliceVar(&showPackageNames, "show-package", []string{}, "Show selected package(s), comma-separated")
-	generateCmd.Flags().BoolVar(&showPackageSPDX, "show-package-spdx", false, "Show SPDX-style JSON for selected package(s)")
+	//generateCmd.Flags().BoolVar(&showPackageSPDX, "show-package-spdx", false, "Show SPDX-style JSON for selected package(s)")
+	generateCmd.Flags().BoolVar(&showPackageSPDX, "show-package-details", false, "Show package metadata details for selected package(s)")
 	generateCmd.Flags().BoolVar(&packagesOnly, "packages-only", false, "Only show package discovery output and skip SBOM output")
 }
 

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -138,25 +138,49 @@ func (g *Generator) GenerateFromAttestations(attestations []attestation.TypedAtt
 	// Run through resolver chain (filtering + resolution)
 	result := g.resolverChain.ResolveAll(files)
     
-	if g.opts.ShowPackages || len(g.opts.ShowPackageNames) > 0 {
-        fmt.Fprintln(os.Stderr, "\n=== DISCOVERED PACKAGES ===")
+if g.opts.ShowPackages || len(g.opts.ShowPackageNames) > 0 {
+        if len(g.opts.ShowPackageNames) > 0 {
+                found := 0
+                missing := 0
+                packageMap := make(map[string]resolver.PackageInfo)
 
-        if len(result.Packages) == 0 {
-                fmt.Fprintln(os.Stderr, "No packages discovered")
-        } else {
                 for _, pkg := range result.Packages {
-                        fmt.Fprintf(os.Stderr, "- %s %s\n", pkg.Name, pkg.Version)
+                        packageMap[strings.ToLower(pkg.Name)] = pkg
                 }
-        }
 
-        fmt.Fprintln(os.Stderr, "===========================\n")
+                fmt.Fprintln(os.Stderr, "\n=== PACKAGE DISCOVERY ===")
+
+                for _, name := range g.opts.ShowPackageNames {
+                        normalizedName := strings.ToLower(strings.TrimSpace(name))
+                        if pkg, ok := packageMap[normalizedName]; ok {
+                                fmt.Fprintf(os.Stderr, "✓ %s %s\n", pkg.Name, pkg.Version)
+                                found++
+                        } else {
+                                fmt.Fprintf(os.Stderr, "✗ %s not found\n", name)
+                                missing++
+                        }
+                }
+
+                fmt.Fprintf(os.Stderr, "\nFound: %d\nMissing: %d\n", found, missing)
+                fmt.Fprintln(os.Stderr, "=========================\n")
+        } else {
+                fmt.Fprintln(os.Stderr, "\n=== DISCOVERED PACKAGES ===")
+
+                if len(result.Packages) == 0 {
+                        fmt.Fprintln(os.Stderr, "No packages discovered")
+                } else {
+                        for _, pkg := range result.Packages {
+                                fmt.Fprintf(os.Stderr, "- %s %s\n", pkg.Name, pkg.Version)
+                        }
+                }
+
+                fmt.Fprintln(os.Stderr, "===========================\n")
+        }
 
         if g.opts.PackagesOnly {
                 return nil
         }
 }
-  
-
 
 
 

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -31,9 +31,9 @@ type Options struct {
 	ProjectDir       string
 
 	ShowPackages     bool
-    ShowPackageNames []string
-    ShowPackageSPDX  bool
-    PackagesOnly     bool
+	ShowPackageNames []string
+	ShowPackageSPDX  bool
+	PackagesOnly     bool
 }
 
 // DefaultOptions returns default generator options
@@ -137,84 +137,73 @@ func (g *Generator) GenerateFromAttestations(attestations []attestation.TypedAtt
 
 	// Run through resolver chain (filtering + resolution)
 	result := g.resolverChain.ResolveAll(files)
-    
-if g.opts.ShowPackages || len(g.opts.ShowPackageNames) > 0 {
-        if len(g.opts.ShowPackageNames) > 0 {
-                found := 0
-                missing := 0
-                packageMap := make(map[string]resolver.PackageInfo)
 
-                for _, pkg := range result.Packages {
-                        packageMap[strings.ToLower(pkg.Name)] = pkg
-                }
+	if g.opts.ShowPackages || len(g.opts.ShowPackageNames) > 0 {
+		if len(g.opts.ShowPackageNames) > 0 {
+			found := 0
+			missing := 0
+			packageMap := make(map[string]resolver.PackageInfo)
 
-                fmt.Fprintln(os.Stderr, "\n=== PACKAGE DISCOVERY ===")
+			for _, pkg := range result.Packages {
+				packageMap[strings.ToLower(pkg.Name)] = pkg
+			}
 
-              
+			fmt.Fprintln(os.Stderr)
 
+			//rahul
+			for _, name := range g.opts.ShowPackageNames {
+				normalizedName := strings.ToLower(strings.TrimSpace(name))
 
-				//rahul
-				for _, name := range g.opts.ShowPackageNames {
-                   normalizedName := strings.ToLower(strings.TrimSpace(name))
+				if pkg, ok := packageMap[normalizedName]; ok {
+					fmt.Fprintf(os.Stderr, "✓ %s %s\n", pkg.Name, pkg.Version)
 
-                    if pkg, ok := packageMap[normalizedName]; ok {
-                fmt.Fprintf(os.Stderr, "✓ %s %s\n", pkg.Name, pkg.Version)
+					if g.opts.ShowPackageSPDX {
+						fmt.Fprintln(os.Stderr, "  Package Details:")
+						fmt.Fprintf(os.Stderr, "    Name: %s\n", pkg.Name)
+						fmt.Fprintf(os.Stderr, "    Version: %s\n", pkg.Version)
+						fmt.Fprintf(os.Stderr, "    Ecosystem: %s\n", pkg.Ecosystem)
+						fmt.Fprintf(os.Stderr, "    PURL: %s\n", pkg.PURL)
 
-                if g.opts.ShowPackageSPDX {
-                        fmt.Fprintln(os.Stderr, "  Package Details:")
-                        fmt.Fprintf(os.Stderr, "    Name: %s\n", pkg.Name)
-                        fmt.Fprintf(os.Stderr, "    Version: %s\n", pkg.Version)
-                        fmt.Fprintf(os.Stderr, "    Ecosystem: %s\n", pkg.Ecosystem)
-                        fmt.Fprintf(os.Stderr, "    PURL: %s\n", pkg.PURL)
+						if len(pkg.Licenses) > 0 {
+							fmt.Fprintf(os.Stderr, "    Licenses: %s\n", strings.Join(pkg.Licenses, ", "))
+						}
 
-                        if len(pkg.Licenses) > 0 {
-                                fmt.Fprintf(os.Stderr, "    Licenses: %s\n", strings.Join(pkg.Licenses, ", "))
-                        }
+						if len(pkg.Hashes) > 0 {
+							fmt.Fprintln(os.Stderr, "    Hashes:")
+							for algo, hash := range pkg.Hashes {
+								fmt.Fprintf(os.Stderr, "      %s: %s\n", algo, hash)
+							}
+						}
+					}
 
-                        if len(pkg.Hashes) > 0 {
-                                fmt.Fprintln(os.Stderr, "    Hashes:")
-                                for algo, hash := range pkg.Hashes {
-                                        fmt.Fprintf(os.Stderr, "      %s: %s\n", algo, hash)
-                                }
-                        }
-                }
+					found++
+				} else {
+					fmt.Fprintf(os.Stderr, "✗ %s not found\n", name)
+					missing++
+				}
+			}
 
-                found++
-        } else {
-                fmt.Fprintf(os.Stderr, "✗ %s not found\n", name)
-                missing++
-        }
-}
+			fmt.Fprintf(os.Stderr, "\nFound: %d\nMissing: %d\n", found, missing)
+			fmt.Fprintln(os.Stderr, "=========================")
+		} else {
+			fmt.Fprintln(os.Stderr)
+			fmt.Fprintln(os.Stderr, "=== DISCOVERED PACKAGES ===")
 
+			if len(result.Packages) == 0 {
+				fmt.Fprintln(os.Stderr, "No packages discovered")
+			} else {
+				for _, pkg := range result.Packages {
+					fmt.Fprintf(os.Stderr, "- %s %s\n", pkg.Name, pkg.Version)
+				}
+			}
 
+			fmt.Fprintln(os.Stderr, "===========================")
+		}
 
-
-
-
-                fmt.Fprintf(os.Stderr, "\nFound: %d\nMissing: %d\n", found, missing)
-                fmt.Fprintln(os.Stderr, "=========================\n")
-        } else {
-                fmt.Fprintln(os.Stderr, "\n=== DISCOVERED PACKAGES ===")
-
-                if len(result.Packages) == 0 {
-                        fmt.Fprintln(os.Stderr, "No packages discovered")
-                } else {
-                        for _, pkg := range result.Packages {
-                                fmt.Fprintf(os.Stderr, "- %s %s\n", pkg.Name, pkg.Version)
-                        }
-                }
-
-                fmt.Fprintln(os.Stderr, "===========================\n")
-        }
-
-        if g.opts.PackagesOnly {
-                return nil
-        }
-}
-
-
-
-
+		if g.opts.PackagesOnly {
+			return nil
+		}
+	}
 
 	// Resolve packages from network connections
 	networkConns := network.ExtractConnections(attestations)

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -29,6 +29,11 @@ type Options struct {
 	OutputPath       string
 	Catalog          string
 	ProjectDir       string
+
+	ShowPackages     bool
+    ShowPackageNames []string
+    ShowPackageSPDX  bool
+    PackagesOnly     bool
 }
 
 // DefaultOptions returns default generator options
@@ -132,6 +137,30 @@ func (g *Generator) GenerateFromAttestations(attestations []attestation.TypedAtt
 
 	// Run through resolver chain (filtering + resolution)
 	result := g.resolverChain.ResolveAll(files)
+    
+	if g.opts.ShowPackages || len(g.opts.ShowPackageNames) > 0 {
+        fmt.Fprintln(os.Stderr, "\n=== DISCOVERED PACKAGES ===")
+
+        if len(result.Packages) == 0 {
+                fmt.Fprintln(os.Stderr, "No packages discovered")
+        } else {
+                for _, pkg := range result.Packages {
+                        fmt.Fprintf(os.Stderr, "- %s %s\n", pkg.Name, pkg.Version)
+                }
+        }
+
+        fmt.Fprintln(os.Stderr, "===========================\n")
+
+        if g.opts.PackagesOnly {
+                return nil
+        }
+}
+  
+
+
+
+
+
 
 	// Resolve packages from network connections
 	networkConns := network.ExtractConnections(attestations)

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -150,16 +150,46 @@ if g.opts.ShowPackages || len(g.opts.ShowPackageNames) > 0 {
 
                 fmt.Fprintln(os.Stderr, "\n=== PACKAGE DISCOVERY ===")
 
-                for _, name := range g.opts.ShowPackageNames {
-                        normalizedName := strings.ToLower(strings.TrimSpace(name))
-                        if pkg, ok := packageMap[normalizedName]; ok {
-                                fmt.Fprintf(os.Stderr, "✓ %s %s\n", pkg.Name, pkg.Version)
-                                found++
-                        } else {
-                                fmt.Fprintf(os.Stderr, "✗ %s not found\n", name)
-                                missing++
+              
+
+
+				//rahul
+				for _, name := range g.opts.ShowPackageNames {
+                   normalizedName := strings.ToLower(strings.TrimSpace(name))
+
+                    if pkg, ok := packageMap[normalizedName]; ok {
+                fmt.Fprintf(os.Stderr, "✓ %s %s\n", pkg.Name, pkg.Version)
+
+                if g.opts.ShowPackageSPDX {
+                        fmt.Fprintln(os.Stderr, "  Package Details:")
+                        fmt.Fprintf(os.Stderr, "    Name: %s\n", pkg.Name)
+                        fmt.Fprintf(os.Stderr, "    Version: %s\n", pkg.Version)
+                        fmt.Fprintf(os.Stderr, "    Ecosystem: %s\n", pkg.Ecosystem)
+                        fmt.Fprintf(os.Stderr, "    PURL: %s\n", pkg.PURL)
+
+                        if len(pkg.Licenses) > 0 {
+                                fmt.Fprintf(os.Stderr, "    Licenses: %s\n", strings.Join(pkg.Licenses, ", "))
+                        }
+
+                        if len(pkg.Hashes) > 0 {
+                                fmt.Fprintln(os.Stderr, "    Hashes:")
+                                for algo, hash := range pkg.Hashes {
+                                        fmt.Fprintf(os.Stderr, "      %s: %s\n", algo, hash)
+                                }
                         }
                 }
+
+                found++
+        } else {
+                fmt.Fprintf(os.Stderr, "✗ %s not found\n", name)
+                missing++
+        }
+}
+
+
+
+
+
 
                 fmt.Fprintf(os.Stderr, "\nFound: %d\nMissing: %d\n", found, missing)
                 fmt.Fprintln(os.Stderr, "=========================\n")

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -7,7 +7,7 @@ type PackageInfo struct {
 	PURL        string            `json:"purl"`
 	Licenses    []string          `json:"licenses,omitempty"`
 	Hashes      map[string]string `json:"hashes,omitempty"`
-	FoundBy     string            `json:"found_by"` // which resolver found this
+	FoundBy     string            `json:"found_by"`               // which resolver found this
 	DownloadURL string            `json:"download_url,omitempty"` // set by network resolvers
 	DownloadIP  string            `json:"download_ip,omitempty"`  // set by network resolvers
 }


### PR DESCRIPTION
<h2><span>Summary</span></h2><p class="isSelectedEnd"><span>Adds CLI support for discovering, searching, and inspecting individual packages from witness attestations — without requiring users to manually search large SBOM outputs.</span></p><h2><span>New Flags</span></h2>
Flag | Description
-- | --
--show-packages | List all packages discovered during attestation processing
--show-package <name> | Search for one or more packages by name (comma-separated)
--show-package-details | Display package metadata (version, ecosystem, PURL, hashes)
--packages-only | Display package information only and skip full SBOM generation

<h2><span>Important Note on </span><code dir="ltr"><span>--packages-only</span></code></h2><p class="isSelectedEnd"><span>By default, package discovery and inspection commands continue execution and generate the full SBOM after displaying the requested package information.</span></p><p class="isSelectedEnd"><span>If you only need package information and want to skip SPDX/CycloneDX generation, use the </span><code dir="ltr"><span>--packages-only</span></code><span> flag.</span></p><p class="isSelectedEnd"><span>This is useful when:</span></p><ul data-spread="false"><li><span>Quickly validating whether a package exists in an attestation</span></li><li><span>Troubleshooting attestation contents</span></li><li><span>Inspecting package metadata</span></li><li><span>Exploring package information without generating a complete SBOM</span></li></ul><h2><span>Motivation</span></h2><p class="isSelectedEnd"><span>SBOM outputs are often large files containing hundreds or thousands of packages, making it difficult to quickly locate a specific package or inspect its metadata.</span></p><p class="isSelectedEnd"><span>Currently, users typically need to generate a full SPDX/CycloneDX document and manually search through the output to verify package presence or investigate package information.</span></p><p class="isSelectedEnd"><span>This feature provides a lightweight workflow for package discovery and metadata inspection directly from witness attestations.</span></p><h2><span>Usage Examples</span></h2><h3><span>List all discovered packages</span></h3><pre dir="ltr"><code dir="ltr"><span>sbomit generate attestation.json --show-packages</span></code></pre><h3><span>Search specific packages</span></h3><pre dir="ltr"><code dir="ltr"><span>sbomit generate attestation.json --show-package flask,pandas</span></code></pre><h3><span>Search and inspect package metadata</span></h3><blockquote><p class="isSelectedEnd"><span>Note: The full SBOM will still be generated after displaying package information.</span></p></blockquote><pre dir="ltr"><code dir="ltr"><span>sbomit generate attestation.json \
  --show-package flask,pandas \
  --show-package-details</span></code></pre><h3><span>Search, inspect, and skip SBOM generation</span></h3><pre dir="ltr"><code dir="ltr"><span>sbomit generate attestation.json \
  --show-package flask,pandas \
  --show-package-details \
  --packages-only</span></code></pre><h2><span>Sample Output</span></h2><pre dir="ltr"><code dir="ltr"><span>=== PACKAGE SEARCH RESULTS ===

✓ flask 3.1.2

  Package Details:
    Name:       flask
    Version:    3.1.2
    Ecosystem:  pypi
    PURL:       pkg:pypi/flask@3.1.2

✓ pandas 2.3.3

  Package Details:
    Name:       pandas
    Version:    2.3.3
    Ecosystem:  pypi
    PURL:       pkg:pypi/pandas@2.3.3

✗ redis not found

==============================
Found:   2
Missing: 1
==============================</span></code></pre><h2><span>Future Work</span></h2><p class="isSelectedEnd"><span>A potential follow-up enhancement would be support for displaying the SPDX/CycloneDX representation of selected packages directly.</span></p><p class="isSelectedEnd"><span>Example:</span></p><pre dir="ltr"><code dir="ltr"><span>sbomit generate attestation.json \
  --show-package flask \
  --show-package-spdx</span></code></pre><p class="isSelectedEnd"><span>This would allow users to inspect the SBOM entry associated with a specific package without generating or searching the entire SBOM document.</span></p><h2><span>Notes</span></h2><p><span>This change is additive and does not modify the existing SBOM generation workflow. Existing commands and output formats continue to work as before.</span></p>