### PR TITLE
feat: add --skip-binary and --skip-dir flags for SBOM filtering 

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -18,8 +18,7 @@ var (
 	attestationTypes []string
 	catalog          string
 	projectDir       string
-	skipBinaries     []string
-	skipDirs         []string
+	skipPaths        []string
 )
 
 var generateCmd = &cobra.Command{
@@ -61,8 +60,7 @@ func init() {
 	generateCmd.Flags().StringSliceVar(&attestationTypes, "types", []string{"material", "command-run", "product", "network-trace"}, "Attestation types to parse (comma-separated).")
 	generateCmd.Flags().StringVarP(&catalog, "catalog", "c", "", "Cataloger to run before processing attestations (supported: syft, trivy)")
 	generateCmd.Flags().StringVar(&projectDir, "project-dir", "", "Project directory to scan with the cataloger (default: current directory)")
-	generateCmd.Flags().StringSliceVar(&skipBinaries, "skip-binary", []string{}, "Exclude binaries matching glob pattern")
-	generateCmd.Flags().StringSliceVar(&skipDirs, "skip-dir", []string{}, "Exclude directories by name or glob pattern")
+	generateCmd.Flags().StringSliceVar(&skipPaths, "skip-path", []string{}, "Exclude paths matching glob pattern")
 }
 
 func runGenerate(attestationFile string) error {
@@ -94,8 +92,7 @@ func runGenerate(attestationFile string) error {
 		OutputPath:       outputPath,
 		Catalog:          catalog,
 		ProjectDir:       projectDir,
-		SkipBinaries:     skipBinaries,
-		SkipDirs:         skipDirs,
+		SkipPaths:        skipPaths,
 	}
 
 	gen := generator.New(opts)

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -18,6 +18,8 @@ var (
 	attestationTypes []string
 	catalog          string
 	projectDir       string
+	skipBinaries     []string
+	skipDirs         []string
 )
 
 var generateCmd = &cobra.Command{
@@ -59,6 +61,8 @@ func init() {
 	generateCmd.Flags().StringSliceVar(&attestationTypes, "types", []string{"material", "command-run", "product", "network-trace"}, "Attestation types to parse (comma-separated).")
 	generateCmd.Flags().StringVarP(&catalog, "catalog", "c", "", "Cataloger to run before processing attestations (supported: syft, trivy)")
 	generateCmd.Flags().StringVar(&projectDir, "project-dir", "", "Project directory to scan with the cataloger (default: current directory)")
+	generateCmd.Flags().StringSliceVar(&skipBinaries, "skip-binary", []string{}, "Exclude binaries matching glob pattern")
+	generateCmd.Flags().StringSliceVar(&skipDirs, "skip-dir", []string{}, "Exclude directories by name or glob pattern")
 }
 
 func runGenerate(attestationFile string) error {
@@ -90,6 +94,8 @@ func runGenerate(attestationFile string) error {
 		OutputPath:       outputPath,
 		Catalog:          catalog,
 		ProjectDir:       projectDir,
+		SkipBinaries:     skipBinaries,
+		SkipDirs:         skipDirs,
 	}
 
 	gen := generator.New(opts)

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -29,6 +30,8 @@ type Options struct {
 	OutputPath       string
 	Catalog          string
 	ProjectDir       string
+	SkipBinaries     []string
+	SkipDirs         []string
 }
 
 // DefaultOptions returns default generator options
@@ -41,6 +44,8 @@ func DefaultOptions() *Options {
 		OutputFormat:     "spdx23",
 		Catalog:          "",
 		ProjectDir:       "",
+		SkipBinaries:     []string{},
+		SkipDirs:         []string{},
 	}
 }
 
@@ -124,6 +129,10 @@ func (g *Generator) GenerateFromAttestations(attestations []attestation.TypedAtt
 	// Convert to resolver.FileInfo format
 	var files []resolver.FileInfo
 	for _, f := range attFiles {
+		if g.shouldSkip(f.Path) {
+			fmt.Fprintf(os.Stderr, "Excluded item: %s\n", f.Path)
+			continue
+		}
 		files = append(files, resolver.FileInfo{
 			Path:   f.Path,
 			Hashes: f.Hashes,
@@ -147,6 +156,34 @@ func (g *Generator) GenerateFromAttestations(attestations []attestation.TypedAtt
 	}
 
 	return g.writeOutput(attDoc)
+}
+
+func (g *Generator) shouldSkip(path string) bool {
+	// Check skip dirs
+	for _, dir := range g.opts.SkipDirs {
+		cleanDir := strings.TrimSuffix(dir, "/")
+		if strings.HasPrefix(path, cleanDir+"/") || path == cleanDir || strings.Contains(path, "/"+cleanDir+"/") {
+			return true
+		}
+		matched, _ := filepath.Match(dir, path)
+		if matched {
+			return true
+		}
+	}
+
+	// Check skip binaries
+	for _, bin := range g.opts.SkipBinaries {
+		matched, err := filepath.Match(bin, path)
+		if err == nil && matched {
+			return true
+		}
+		matchedBase, err := filepath.Match(bin, filepath.Base(path))
+		if err == nil && matchedBase {
+			return true
+		}
+	}
+
+	return false
 }
 
 // mergeNetworkPackages merges network-resolved packages into the file-resolved result.

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -30,8 +30,7 @@ type Options struct {
 	OutputPath       string
 	Catalog          string
 	ProjectDir       string
-	SkipBinaries     []string
-	SkipDirs         []string
+	SkipPaths        []string
 }
 
 // DefaultOptions returns default generator options
@@ -44,8 +43,7 @@ func DefaultOptions() *Options {
 		OutputFormat:     "spdx23",
 		Catalog:          "",
 		ProjectDir:       "",
-		SkipBinaries:     []string{},
-		SkipDirs:         []string{},
+		SkipPaths:        []string{},
 	}
 }
 
@@ -159,30 +157,13 @@ func (g *Generator) GenerateFromAttestations(attestations []attestation.TypedAtt
 }
 
 func (g *Generator) shouldSkip(path string) bool {
-	// Check skip dirs
-	for _, dir := range g.opts.SkipDirs {
-		cleanDir := strings.TrimSuffix(dir, "/")
-		if strings.HasPrefix(path, cleanDir+"/") || path == cleanDir || strings.Contains(path, "/"+cleanDir+"/") {
-			return true
-		}
-		matched, _ := filepath.Match(dir, path)
+	// Check skip paths
+	for _, pattern := range g.opts.SkipPaths {
+		matched, _ := filepath.Match(pattern, path)
 		if matched {
 			return true
 		}
 	}
-
-	// Check skip binaries
-	for _, bin := range g.opts.SkipBinaries {
-		matched, err := filepath.Match(bin, path)
-		if err == nil && matched {
-			return true
-		}
-		matchedBase, err := filepath.Match(bin, filepath.Base(path))
-		if err == nil && matchedBase {
-			return true
-		}
-	}
-
 	return false
 }
 


### PR DESCRIPTION
# Description
This PR resolves #52 by adding the ability to exclude specific native binaries and directories from the generated SBOM.

Two new CLI flags have been introduced to the generate command:

--skip-binary: Excludes binaries matching a given glob pattern or exact name ( *.so).
--skip-dir: Excludes all files under a specified directory name or directory glob pattern ( usr/ or build/).
Excluded items are omitted from the resulting SBOM and their exclusion is logged to stderr for visibility.

# How to Test

1. Build the CLI tool locally:
`` go build -o sbomit ./main.go ``

2. Run generation with sample data, applying filters:
`./sbomit generate test/sample-attestation.json --skip-dir usr/ --skip-binary "*.so" > sbom.json`
