### PR TITLE
feat: add default SBOM summary report with detailed --summary mode

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -20,6 +20,7 @@ var (
 	catalogFile      string
 	projectDir       string
 	skipPaths        []string
+	summaryFlag      bool
 )
 
 var generateCmd = &cobra.Command{
@@ -63,6 +64,7 @@ func init() {
 	generateCmd.Flags().StringVar(&catalogFile, "catalog-file", "", "Existing SBOM catalog file to merge with attestation-derived packages")
 	generateCmd.Flags().StringVar(&projectDir, "project-dir", "", "Project directory to scan with the cataloger (default: current directory)")
 	generateCmd.Flags().StringSliceVar(&skipPaths, "skip-path", []string{}, "Exclude paths matching glob pattern")
+	generateCmd.Flags().BoolVar(&summaryFlag, "summary", false, "Also print per-package details under each ecosystem (default: only ecosystem counts are shown)")
 }
 
 func runGenerate(attestationFile string) error {
@@ -107,9 +109,12 @@ func runGenerate(attestationFile string) error {
 	}
 
 	gen := generator.New(opts)
-	if err := gen.GenerateFromFile(attestationFile); err != nil {
+	doc, err := gen.GenerateFromFile(attestationFile)
+	if err != nil {
 		return fmt.Errorf("failed to generate SBOM: %w", err)
 	}
+
+	generator.WriteSummary(os.Stderr, generator.GenerateSummary(doc), summaryFlag)
 
 	if outputPath != "" {
 		fmt.Fprintf(os.Stderr, "SBOM written to %s\n", outputPath)

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -1,0 +1,184 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunGenerateStdoutAndStderrSeparation(t *testing.T) {
+	restore := snapshotGenerateGlobals()
+	defer restore()
+
+	outputPath = ""
+	outputFormat = "spdx23"
+	documentName = "sbomit-sbom"
+	documentVersion = "0.0.1"
+	authors = nil
+	attestationTypes = []string{"material", "command-run", "product", "network-trace"}
+	catalog = ""
+	projectDir = ""
+	skipPaths = nil
+	summaryFlag = false
+
+	stdout, stderr, err := captureGenerateOutput(t, filepath.Join("..", "test", "sample-attestation.json"))
+	if err != nil {
+		t.Fatalf("runGenerate returned error: %v", err)
+	}
+
+	if !strings.Contains(stdout, "\"spdxVersion\"") {
+		t.Fatalf("expected SBOM JSON on stdout, got: %s", stdout)
+	}
+	if strings.Contains(stdout, "SBOM Summary") {
+		t.Fatalf("did not expect summary output on stdout: %s", stdout)
+	}
+	if !strings.Contains(stderr, "SBOM Summary") {
+		t.Fatalf("expected summary output on stderr, got: %s", stderr)
+	}
+	if !strings.Contains(stderr, "Total Packages:") || !strings.Contains(stderr, "Total Files:") {
+		t.Fatalf("expected brief summary counts on stderr, got: %s", stderr)
+	}
+	if strings.Contains(stderr, "    - pkg:") {
+		t.Fatalf("did not expect detailed package listing without --summary: %s", stderr)
+	}
+}
+
+func TestRunGenerateDetailedSummaryToStderrWithFileOutput(t *testing.T) {
+	restore := snapshotGenerateGlobals()
+	defer restore()
+
+	tmpDir := t.TempDir()
+	target := filepath.Join(tmpDir, "sbom.json")
+
+	outputPath = target
+	outputFormat = "spdx23"
+	documentName = "sbomit-sbom"
+	documentVersion = "0.0.1"
+	authors = nil
+	attestationTypes = []string{"material", "command-run", "product", "network-trace"}
+	catalog = ""
+	projectDir = ""
+	skipPaths = nil
+	summaryFlag = true
+
+	stdout, stderr, err := captureGenerateOutput(t, filepath.Join("..", "test", "sample-attestation.json"))
+	if err != nil {
+		t.Fatalf("runGenerate returned error: %v", err)
+	}
+
+	if stdout != "" {
+		t.Fatalf("expected no stdout when writing SBOM to file, got: %s", stdout)
+	}
+	if !strings.Contains(stderr, "SBOM Summary") {
+		t.Fatalf("expected summary output on stderr, got: %s", stderr)
+	}
+	if !strings.Contains(stderr, "    - pkg:") {
+		t.Fatalf("expected detailed package listing on stderr, got: %s", stderr)
+	}
+	if !strings.Contains(stderr, "SBOM written to "+target) {
+		t.Fatalf("expected file output message on stderr, got: %s", stderr)
+	}
+
+	written, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("failed to read generated SBOM file: %v", err)
+	}
+	if !bytes.Contains(written, []byte("\"spdxVersion\"")) {
+		t.Fatalf("expected SBOM JSON in output file, got: %s", string(written))
+	}
+}
+
+func snapshotGenerateGlobals() func() {
+	prevOutputPath := outputPath
+	prevOutputFormat := outputFormat
+	prevDocumentName := documentName
+	prevDocumentVersion := documentVersion
+	prevAuthors := append([]string(nil), authors...)
+	prevAttestationTypes := append([]string(nil), attestationTypes...)
+	prevCatalog := catalog
+	prevProjectDir := projectDir
+	prevSkipPaths := append([]string(nil), skipPaths...)
+	prevSummaryFlag := summaryFlag
+
+	return func() {
+		outputPath = prevOutputPath
+		outputFormat = prevOutputFormat
+		documentName = prevDocumentName
+		documentVersion = prevDocumentVersion
+		authors = prevAuthors
+		attestationTypes = prevAttestationTypes
+		catalog = prevCatalog
+		projectDir = prevProjectDir
+		skipPaths = prevSkipPaths
+		summaryFlag = prevSummaryFlag
+	}
+}
+
+func captureGenerateOutput(t *testing.T, attestationFile string) (string, string, error) {
+	t.Helper()
+
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdout pipe: %v", err)
+	}
+	stderrR, stderrW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stderr pipe: %v", err)
+	}
+
+	os.Stdout = stdoutW
+	os.Stderr = stderrW
+
+	stdoutCh := make(chan []byte, 1)
+	stderrCh := make(chan []byte, 1)
+	errCh := make(chan error, 2)
+
+	go func() {
+		data, err := readAllPipe(stdoutR)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		stdoutCh <- data
+	}()
+	go func() {
+		data, err := readAllPipe(stderrR)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		stderrCh <- data
+	}()
+
+	runErr := runGenerate(attestationFile)
+
+	_ = stdoutW.Close()
+	_ = stderrW.Close()
+	os.Stdout = origStdout
+	os.Stderr = origStderr
+
+	stdoutBytes := <-stdoutCh
+	stderrBytes := <-stderrCh
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("failed to capture command output: %v", err)
+	default:
+	}
+
+	_ = stdoutR.Close()
+	_ = stderrR.Close()
+
+	return string(stdoutBytes), string(stderrBytes), runErr
+}
+
+func readAllPipe(f *os.File) ([]byte, error) {
+	var buf bytes.Buffer
+	_, err := buf.ReadFrom(f)
+	return buf.Bytes(), err
+}

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -66,10 +66,10 @@ func New(opts *Options) *Generator {
 	}
 }
 
-func (g *Generator) GenerateFromFile(attestationPath string) error {
+func (g *Generator) GenerateFromFile(attestationPath string) (*sbom.Document, error) {
 	attestations, err := attestation.ParseWitnessFile(attestationPath, g.opts.AttestationTypes)
 	if err != nil {
-		return fmt.Errorf("failed to parse attestation file: %w", err)
+		return nil, fmt.Errorf("failed to parse attestation file: %w", err)
 	}
 	g.printParsedAttestationSummary(attestations)
 	return g.GenerateFromAttestations(attestations)
@@ -98,7 +98,7 @@ func (g *Generator) printParsedAttestationSummary(attestations []attestation.Typ
 	fmt.Fprintf(os.Stderr, "Parsed attestations (%d total): %s\n", len(attestations), strings.Join(parts, ", "))
 }
 
-func (g *Generator) GenerateFromAttestations(attestations []attestation.TypedAttestation) error {
+func (g *Generator) GenerateFromAttestations(attestations []attestation.TypedAttestation) (*sbom.Document, error) {
 	var baseDoc *sbom.Document
 	var err error
 
@@ -106,7 +106,7 @@ func (g *Generator) GenerateFromAttestations(attestations []attestation.TypedAtt
 	if projectDir == "" {
 		projectDir, err = os.Getwd()
 		if err != nil {
-			return fmt.Errorf("failed to determine project directory: %w", err)
+			return nil, fmt.Errorf("failed to determine project directory: %w", err)
 		}
 	}
 
@@ -114,18 +114,18 @@ func (g *Generator) GenerateFromAttestations(attestations []attestation.TypedAtt
 	case "syft":
 		baseDoc, err = g.runSyft(projectDir)
 		if err != nil {
-			return fmt.Errorf("failed to run syft: %w", err)
+			return nil, fmt.Errorf("failed to run syft: %w", err)
 		}
 	case "trivy":
 		baseDoc, err = g.runTrivy(projectDir)
 		if err != nil {
-			return fmt.Errorf("failed to run trivy: %w", err)
+			return nil, fmt.Errorf("failed to run trivy: %w", err)
 		}
 	default:
 		if strings.TrimSpace(g.opts.CatalogFile) != "" {
 			baseDoc, err = g.readCatalogFile(g.opts.CatalogFile)
 			if err != nil {
-				return err
+				return nil, err
 			}
 		}
 	}
@@ -158,10 +158,12 @@ func (g *Generator) GenerateFromAttestations(attestations []attestation.TypedAtt
 	if baseDoc != nil {
 		g.applyMetadata(baseDoc)
 		g.mergePreferAttestation(baseDoc, attDoc)
-		return g.writeOutput(baseDoc)
+		err = g.writeOutput(baseDoc)
+		return baseDoc, err
 	}
 
-	return g.writeOutput(attDoc)
+	err = g.writeOutput(attDoc)
+	return attDoc, err
 }
 
 func (g *Generator) shouldSkip(path string) bool {

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -41,7 +41,7 @@ func TestGenerateFromAttestationsCanUseCatalogFile(t *testing.T) {
 		ProjectDir:       "/does/not/exist",
 	})
 
-	if err := gen.GenerateFromAttestations(nil); err != nil {
+	if _, err := gen.GenerateFromAttestations(nil); err != nil {
 		t.Fatalf("generate with catalog file: %v", err)
 	}
 

--- a/pkg/generator/summary.go
+++ b/pkg/generator/summary.go
@@ -1,0 +1,95 @@
+package generator
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/protobom/protobom/pkg/sbom"
+)
+
+type Summary struct {
+	TotalPackages       int
+	TotalFiles          int
+	PackagesByEcosystem map[string][]string
+}
+
+func GenerateSummary(doc *sbom.Document) Summary {
+	summary := Summary{
+		PackagesByEcosystem: make(map[string][]string),
+	}
+
+	if doc == nil || doc.NodeList == nil {
+		return summary
+	}
+
+	rootElements := make(map[string]bool, len(doc.NodeList.RootElements))
+	for _, id := range doc.NodeList.RootElements {
+		rootElements[id] = true
+	}
+
+	for _, node := range doc.NodeList.Nodes {
+		if rootElements[node.Id] {
+			continue
+		}
+		switch node.Type {
+		case sbom.Node_PACKAGE:
+			summary.TotalPackages++
+			ecosystem, item := summarizePackageNode(node)
+			summary.PackagesByEcosystem[ecosystem] = append(summary.PackagesByEcosystem[ecosystem], item)
+		case sbom.Node_FILE:
+			summary.TotalFiles++
+		}
+	}
+
+	return summary
+}
+
+func summarizePackageNode(node *sbom.Node) (string, string) {
+	purl := string(node.Purl())
+
+	// Only catalog-merged (syft/trivy) nodes can lack a PURL.
+	if purl == "" {
+		name := node.Name
+		if name == "" {
+			name = "unknown-package"
+		}
+		return "unclassified", name
+	}
+
+	if after, ok := strings.CutPrefix(purl, "pkg:"); ok && after != "" {
+		if ecosystem := strings.SplitN(after, "/", 2)[0]; ecosystem != "" {
+			return ecosystem, purl
+		}
+	}
+	return "unclassified", purl
+}
+
+func WriteSummary(w io.Writer, summary Summary, detailed bool) {
+	fmt.Fprintln(w, "SBOM Summary")
+	fmt.Fprintln(w, "------------")
+	fmt.Fprintf(w, "Total Packages: %d\n", summary.TotalPackages)
+	fmt.Fprintf(w, "Total Files: %d\n", summary.TotalFiles)
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Ecosystem Breakdown:")
+
+	if len(summary.PackagesByEcosystem) == 0 {
+		fmt.Fprintln(w, "  none")
+		return
+	}
+
+	for ecosystem, pkgs := range summary.PackagesByEcosystem {
+		fmt.Fprintf(w, "  %s: %d\n", ecosystem, len(pkgs))
+		if !detailed {
+			continue
+		}
+
+		items := append([]string(nil), pkgs...)
+		sort.Strings(items)
+		for _, item := range items {
+			fmt.Fprintf(w, "    - %s\n", item)
+		}
+	}
+}

--- a/pkg/generator/summary_test.go
+++ b/pkg/generator/summary_test.go
@@ -1,0 +1,143 @@
+package generator
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/protobom/protobom/pkg/sbom"
+)
+
+func TestGenerateSummaryCountsPackagesFilesAndEcosystems(t *testing.T) {
+	doc := &sbom.Document{
+		NodeList: &sbom.NodeList{
+			Nodes: []*sbom.Node{
+				{
+					Id:   "pkg-1",
+					Type: sbom.Node_PACKAGE,
+					Identifiers: map[int32]string{
+						int32(sbom.SoftwareIdentifierType_PURL): "pkg:npm/react@18.2.0",
+					},
+				},
+				{
+					Id:   "pkg-2",
+					Type: sbom.Node_PACKAGE,
+					Identifiers: map[int32]string{
+						int32(sbom.SoftwareIdentifierType_PURL): "pkg:golang/github.com/spf13/cobra@v1.8.1",
+					},
+				},
+				{
+					Id:   "pkg-3",
+					Type: sbom.Node_PACKAGE,
+				},
+				{
+					Id:   "file-1",
+					Type: sbom.Node_FILE,
+				},
+			},
+		},
+	}
+
+	summary := GenerateSummary(doc)
+
+	if summary.TotalPackages != 3 {
+		t.Fatalf("expected 3 total packages, got %d", summary.TotalPackages)
+	}
+	if summary.TotalFiles != 1 {
+		t.Fatalf("expected 1 total file, got %d", summary.TotalFiles)
+	}
+	if got := len(summary.PackagesByEcosystem["npm"]); got != 1 {
+		t.Fatalf("expected 1 npm package, got %d", got)
+	}
+	if got := len(summary.PackagesByEcosystem["golang"]); got != 1 {
+		t.Fatalf("expected 1 golang package, got %d", got)
+	}
+	if got := len(summary.PackagesByEcosystem["unclassified"]); got != 1 {
+		t.Fatalf("expected 1 unclassified package, got %d", got)
+	}
+}
+
+func TestGenerateSummarySkipsRootNode(t *testing.T) {
+	rootID := "document-root"
+	doc := &sbom.Document{
+		NodeList: &sbom.NodeList{
+			RootElements: []string{rootID},
+			Nodes: []*sbom.Node{
+				{
+					Id: rootID,
+				},
+				{
+					Id:   "pkg-1",
+					Type: sbom.Node_PACKAGE,
+					Identifiers: map[int32]string{
+						int32(sbom.SoftwareIdentifierType_PURL): "pkg:npm/lodash@4.17.21",
+					},
+				},
+			},
+		},
+	}
+
+	summary := GenerateSummary(doc)
+
+	if summary.TotalPackages != 1 {
+		t.Fatalf("expected 1 package (root node must be skipped), got %d", summary.TotalPackages)
+	}
+	if got := len(summary.PackagesByEcosystem["unclassified"]); got != 0 {
+		t.Fatalf("expected 0 unclassified packages (root node must be skipped), got %d", got)
+	}
+}
+
+func TestGenerateSummaryHandlesInvalidPURLsAsUnclassified(t *testing.T) {
+	doc := &sbom.Document{
+		NodeList: &sbom.NodeList{
+			Nodes: []*sbom.Node{
+				{
+					Id:   "invalid-purl",
+					Type: sbom.Node_PACKAGE,
+					Identifiers: map[int32]string{
+						int32(sbom.SoftwareIdentifierType_PURL): "not-a-purl",
+					},
+				},
+			},
+		},
+	}
+
+	summary := GenerateSummary(doc)
+
+	if got := len(summary.PackagesByEcosystem["unclassified"]); got != 1 {
+		t.Fatalf("expected invalid purl package to be unclassified, got %#v", summary.PackagesByEcosystem)
+	}
+	if got := summary.PackagesByEcosystem["unclassified"][0]; got != "not-a-purl" {
+		t.Fatalf("expected invalid purl to be kept in detail output, got %q", got)
+	}
+}
+
+func TestWriteSummaryDetailedOutput(t *testing.T) {
+	summary := Summary{
+		TotalPackages: 3,
+		TotalFiles:    1,
+		PackagesByEcosystem: map[string][]string{
+			"zeta":  {"pkg:zeta/two@2.0.0", "pkg:zeta/one@1.0.0"},
+			"alpha": {"pkg:alpha/pkg@1.0.0"},
+		},
+	}
+
+	var buf bytes.Buffer
+	WriteSummary(&buf, summary, true)
+	output := buf.String()
+
+	// Each ecosystem section must appear.
+	if !strings.Contains(output, "alpha: 1") {
+		t.Fatalf("expected 'alpha: 1' in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "zeta: 2") {
+		t.Fatalf("expected 'zeta: 2' in output, got:\n%s", output)
+	}
+
+	// Per-package items within an ecosystem must be sorted alphabetically.
+	oneIdx := strings.Index(output, "    - pkg:zeta/one@1.0.0")
+	twoIdx := strings.Index(output, "    - pkg:zeta/two@2.0.0")
+	if oneIdx == -1 || twoIdx == -1 || oneIdx > twoIdx {
+		t.Fatalf("expected detailed package listings to be sorted alphabetically, got:\n%s", output)
+	}
+}


### PR DESCRIPTION
Fixes #27 

## What changed
- add a brief SBOM summary report by default after sbomit generate
- keep --summary as the detailed mode with per-ecosystem package listings
- send the human-readable report to stderr so SBOM output on stdout stays machine-readable
- preserve the current syft and trivy cataloger behavior while refactoring generation to return the built document for reporting
- add summary logic and command-level tests for counts, classification, deterministic ordering, and stdout/stderr separation

## Behavior
- default output now includes total packages, total files, and ecosystem counts
- --summary extends that with sorted package listings grouped by ecosystem
- file output still prints the report to stderr and keeps the written SBOM valid

## Validation
- GOCACHE=/tmp/sbomit-gocache go test ./...
- verified a live sample run with test/sample-attestation.json to confirm summary text goes to stderr

This supersedes #26 because that branch remained incomplete and mixed summary behavior in a way that could interfere with stdout-based SBOM consumption.