### PR TITLE
Fix go cache parsing issues. Add tests.

### DIFF
--- a/pkg/resolver/go.go
+++ b/pkg/resolver/go.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"net/url"
 	"path"
 	"regexp"
 	"strings"
@@ -14,7 +15,7 @@ type GoResolver struct {
 func NewGoResolver() *GoResolver {
 	return &GoResolver{
 		moduleDirRe:   regexp.MustCompile(`pkg/mod/([^@]+)@([^/]+)/`),
-		moduleCacheRe: regexp.MustCompile(`pkg/mod/cache/download/(.+)/@v/([^/]+)\.(mod|zip|info)`),
+		moduleCacheRe: regexp.MustCompile(`pkg/mod/cache/download/(.+)/@v/([^/]+)\.(mod|zip|info|ziphash)`),
 	}
 }
 
@@ -23,7 +24,8 @@ func (r *GoResolver) Name() string {
 }
 
 func (r *GoResolver) Resolve(files []FileInfo) (packages []PackageInfo, remainingFiles []FileInfo) {
-	seen := make(map[string]struct{})
+	byKey := make(map[string]*PackageInfo)
+	order := []string{}
 
 	for _, f := range files {
 		np := path.Clean(f.Path)
@@ -41,21 +43,26 @@ func (r *GoResolver) Resolve(files []FileInfo) (packages []PackageInfo, remainin
 
 		module = DecodeGoModulePath(module)
 		key := module + "@" + version
-		if _, ok := seen[key]; ok {
-			continue
+		pkg, ok := byKey[key]
+		if !ok {
+			pkg = &PackageInfo{
+				Name:      module,
+				Version:   version,
+				Ecosystem: "golang",
+				PURL:      "pkg:golang/" + module + "@" + encodeGoPURLVersion(version),
+				FoundBy:   "attestation:go",
+			}
+			byKey[key] = pkg
+			order = append(order, key)
 		}
-		seen[key] = struct{}{}
 
-		purl := "pkg:golang/" + module + "@" + version
-		pkg := PackageInfo{
-			Name:      module,
-			Version:   version,
-			Ecosystem: "golang",
-			PURL:      purl,
-			Hashes:    f.Hashes,
-			FoundBy:   "attestation:go",
+		if !r.isModuleCachePath(np) && len(pkg.Hashes) == 0 {
+			pkg.Hashes = f.Hashes
 		}
-		packages = append(packages, pkg)
+	}
+
+	for _, key := range order {
+		packages = append(packages, *byKey[key])
 	}
 
 	return packages, remainingFiles
@@ -110,14 +117,22 @@ func (r *GoResolver) isGoPath(p string) bool {
 	return strings.Contains(p, "/pkg/mod/")
 }
 
+func (r *GoResolver) isModuleCachePath(p string) bool {
+	return strings.Contains(p, "/pkg/mod/cache/download/")
+}
+
 func (r *GoResolver) extractModuleVersion(p string) (string, string, bool) {
-	if matches := r.moduleDirRe.FindStringSubmatch(p); len(matches) == 3 {
-		return matches[1], matches[2], true
-	}
 	if matches := r.moduleCacheRe.FindStringSubmatch(p); len(matches) == 4 {
 		return matches[1], matches[2], true
 	}
+	if matches := r.moduleDirRe.FindStringSubmatch(p); len(matches) == 3 {
+		return matches[1], matches[2], true
+	}
 	return "", "", false
+}
+
+func encodeGoPURLVersion(version string) string {
+	return strings.ReplaceAll(url.PathEscape(version), "+", "%2B")
 }
 
 func goModulePathVariants(module string) []string {

--- a/pkg/resolver/go_test.go
+++ b/pkg/resolver/go_test.go
@@ -1,0 +1,76 @@
+package resolver
+
+import "testing"
+
+func TestGoResolverResolvesModuleCacheDownloadFiles(t *testing.T) {
+	r := NewGoResolver()
+
+	packages, remaining := r.Resolve([]FileInfo{
+		{
+			Path: "/home/user/go/pkg/mod/cache/download/github.com/!burnt!sushi/toml/@v/v1.6.0.mod",
+			Hashes: map[string]string{
+				"sha256": "abc123",
+			},
+		},
+		{
+			Path: "/home/user/go/pkg/mod/cache/download/github.com/!burnt!sushi/toml/@v/v1.6.0.ziphash",
+			Hashes: map[string]string{
+				"sha256": "def456",
+			},
+		},
+		{Path: "/repo/main.go"},
+	})
+
+	if len(remaining) != 1 {
+		t.Fatalf("expected one remaining file, got %d", len(remaining))
+	}
+	if len(packages) != 1 {
+		t.Fatalf("expected one package, got %d", len(packages))
+	}
+
+	pkg := packages[0]
+	if pkg.PURL != "pkg:golang/github.com/BurntSushi/toml@v1.6.0" {
+		t.Fatalf("unexpected PURL: %s", pkg.PURL)
+	}
+	if pkg.Name != "github.com/BurntSushi/toml" {
+		t.Fatalf("unexpected package name: %s", pkg.Name)
+	}
+	if len(pkg.Hashes) != 0 {
+		t.Fatalf("cache file hashes should not be promoted to package hashes: %#v", pkg.Hashes)
+	}
+}
+
+func TestGoResolverAggregatesModuleCacheAndSourcePaths(t *testing.T) {
+	r := NewGoResolver()
+
+	packages, remaining := r.Resolve([]FileInfo{
+		{Path: "/home/user/go/pkg/mod/github.com/pkg/errors@v0.9.1/errors.go"},
+		{Path: "/home/user/go/pkg/mod/cache/download/github.com/pkg/errors/@v/v0.9.1.mod"},
+		{Path: "/home/user/go/pkg/mod/cache/download/github.com/pkg/errors/@v/v0.9.1.info"},
+	})
+
+	if len(remaining) != 0 {
+		t.Fatalf("expected no remaining files, got %d", len(remaining))
+	}
+	if len(packages) != 1 {
+		t.Fatalf("expected one package, got %d", len(packages))
+	}
+	if packages[0].PURL != "pkg:golang/github.com/pkg/errors@v0.9.1" {
+		t.Fatalf("unexpected PURL: %s", packages[0].PURL)
+	}
+}
+
+func TestGoResolverEscapesPURLVersion(t *testing.T) {
+	r := NewGoResolver()
+
+	packages, _ := r.Resolve([]FileInfo{
+		{Path: "/home/user/go/pkg/mod/github.com/peterbourgon/diskv@v2.0.1+incompatible/diskv.go"},
+	})
+
+	if len(packages) != 1 {
+		t.Fatalf("expected one package, got %d", len(packages))
+	}
+	if packages[0].PURL != "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible" {
+		t.Fatalf("unexpected PURL: %s", packages[0].PURL)
+	}
+}


### PR DESCRIPTION
The current resolver for go has a bug which does not properly parse package versions for go cache paths in the form of `.../@v/vX.Y.Z` and a few other cases:

- pkg/mod/cache/download/.../@v/*.ziphash is now recognized.
- Duplicate source/cache paths for the same module now collapse into one package.
- Hashes from Go cache metadata files are no longer promoted as package hashes.
- Go PURL versions now escape +, so v2.0.1+incompatible becomes v2.0.1%2Bincompatible.

This PR fixes and adds tests for them.