### PR TITLE
Add support + test for --catalog-file CLI option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Usage:
 
 Flags:
       --author strings       Document authors (can be specified multiple times)
-  -c, --catalog string       Cataloger to run before processing attestations (supported: syft)
+  -c, --catalog string       Cataloger to run before processing attestations (supported: syft, trivy)
+      --catalog-file string  Existing SBOM catalog file to merge with attestation-derived packages
   -f, --format string        SBOM output format (supported: spdx23, spdx22, cdx14, cdx15) (default "spdx23")
   -h, --help                 help for generate
   -n, --name string          Name for the SBOM document (default "sbomit-sbom")
@@ -49,6 +50,20 @@ Example:
 ```bash
 sbomit generate attestation.json --catalog syft --project-dir /path/to/project
 ```
+
+## Catalog File Option
+
+If you already have an SBOM from another cataloger, pass it with `--catalog-file`.
+Sbomit will use that file as the base catalog and merge packages resolved from the
+Witness attestation into it.
+
+Example:
+
+```bash
+sbomit generate attestation.json --catalog-file existing.spdx.json --output merged.spdx.json
+```
+
+`--catalog-file` cannot be used with `--catalog`; use one catalog source per run.
 
 ## Development
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -17,6 +17,7 @@ var (
 	authors          []string
 	attestationTypes []string
 	catalog          string
+	catalogFile      string
 	projectDir       string
 	skipPaths        []string
 )
@@ -59,6 +60,7 @@ func init() {
 	generateCmd.Flags().StringSliceVar(&authors, "author", []string{}, "Document authors (can be specified multiple times)")
 	generateCmd.Flags().StringSliceVar(&attestationTypes, "types", []string{"material", "command-run", "product", "network-trace"}, "Attestation types to parse (comma-separated).")
 	generateCmd.Flags().StringVarP(&catalog, "catalog", "c", "", "Cataloger to run before processing attestations (supported: syft, trivy)")
+	generateCmd.Flags().StringVar(&catalogFile, "catalog-file", "", "Existing SBOM catalog file to merge with attestation-derived packages")
 	generateCmd.Flags().StringVar(&projectDir, "project-dir", "", "Project directory to scan with the cataloger (default: current directory)")
 	generateCmd.Flags().StringSliceVar(&skipPaths, "skip-path", []string{}, "Exclude paths matching glob pattern")
 }
@@ -82,6 +84,14 @@ func runGenerate(attestationFile string) error {
 	if !validCatalogs[strings.ToLower(catalog)] {
 		return fmt.Errorf("invalid catalog: %s (supported: syft, trivy)", catalog)
 	}
+	if catalog != "" && catalogFile != "" {
+		return fmt.Errorf("--catalog and --catalog-file cannot be used together")
+	}
+	if catalogFile != "" {
+		if _, err := os.Stat(catalogFile); os.IsNotExist(err) {
+			return fmt.Errorf("catalog file not found: %s", catalogFile)
+		}
+	}
 
 	opts := &generator.Options{
 		DocumentName:     documentName,
@@ -91,6 +101,7 @@ func runGenerate(attestationFile string) error {
 		OutputFormat:     outputFormat,
 		OutputPath:       outputPath,
 		Catalog:          catalog,
+		CatalogFile:      catalogFile,
 		ProjectDir:       projectDir,
 		SkipPaths:        skipPaths,
 	}

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -29,6 +29,7 @@ type Options struct {
 	OutputFormat     string
 	OutputPath       string
 	Catalog          string
+	CatalogFile      string
 	ProjectDir       string
 	SkipPaths        []string
 }
@@ -42,6 +43,7 @@ func DefaultOptions() *Options {
 		AttestationTypes: []string{"material", "command-run", "product", "network-trace"},
 		OutputFormat:     "spdx23",
 		Catalog:          "",
+		CatalogFile:      "",
 		ProjectDir:       "",
 		SkipPaths:        []string{},
 	}
@@ -120,6 +122,12 @@ func (g *Generator) GenerateFromAttestations(attestations []attestation.TypedAtt
 			return fmt.Errorf("failed to run trivy: %w", err)
 		}
 	default:
+		if strings.TrimSpace(g.opts.CatalogFile) != "" {
+			baseDoc, err = g.readCatalogFile(g.opts.CatalogFile)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	attFiles := attestation.ExtractFilesFromAttestations(attestations, g.opts.AttestationTypes)
@@ -367,6 +375,14 @@ func (g *Generator) mergePreferAttestation(baseDoc *sbom.Document, attDoc *sbom.
 	mergeList.Edges = attDoc.NodeList.Edges
 	mergeList.RootElements = attDoc.NodeList.RootElements
 	baseDoc.NodeList.Add(mergeList)
+}
+
+func (g *Generator) readCatalogFile(path string) (*sbom.Document, error) {
+	doc, err := reader.New().ParseFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read catalog file %s: %w", path, err)
+	}
+	return doc, nil
 }
 
 func (g *Generator) runSyft(projectDir string) (*sbom.Document, error) {

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -1,0 +1,60 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/protobom/protobom/pkg/formats"
+	"github.com/protobom/protobom/pkg/sbom"
+	"github.com/protobom/protobom/pkg/writer"
+)
+
+func TestGenerateFromAttestationsCanUseCatalogFile(t *testing.T) {
+	tmp := t.TempDir()
+	catalogPath := tmp + "/catalog.spdx.json"
+	outPath := tmp + "/out.spdx.json"
+
+	catalogDoc := sbom.NewDocument()
+	catalogDoc.Metadata.Id = "urn:uuid:test-catalog"
+	catalogDoc.Metadata.Name = "catalog"
+	catalogNode := &sbom.Node{
+		Id:      "pkg:generic/catalog-package@1.0.0",
+		Type:    sbom.Node_PACKAGE,
+		Name:    "catalog-package",
+		Version: "1.0.0",
+		Identifiers: map[int32]string{
+			int32(sbom.SoftwareIdentifierType_PURL): "pkg:generic/catalog-package@1.0.0",
+		},
+	}
+	catalogDoc.NodeList.AddRootNode(catalogNode)
+
+	if err := writer.New().WriteFileWithOptions(catalogDoc, catalogPath, &writer.Options{Format: formats.SPDX23JSON}); err != nil {
+		t.Fatalf("write catalog SBOM: %v", err)
+	}
+
+	gen := New(&Options{
+		DocumentName:     "test",
+		DocumentVersion:  "0.0.1",
+		AttestationTypes: []string{},
+		OutputFormat:     "spdx23",
+		OutputPath:       outPath,
+		CatalogFile:      catalogPath,
+		ProjectDir:       "/does/not/exist",
+	})
+
+	if err := gen.GenerateFromAttestations(nil); err != nil {
+		t.Fatalf("generate with catalog file: %v", err)
+	}
+
+	outDoc, err := gen.readCatalogFile(outPath)
+	if err != nil {
+		t.Fatalf("read output SBOM: %v", err)
+	}
+
+	for _, node := range outDoc.NodeList.Nodes {
+		if node != nil && node.Id == "pkg:generic/catalog-package@1.0.0" {
+			return
+		}
+	}
+
+	t.Fatal("catalog package was not preserved")
+}


### PR DESCRIPTION
This PR adds support for `sbomit` to directly take as input a protobom compatible format for a base SBOM instead of only supporting launching Syft and Trivy. 

This makes it much more convenient when running comparison experiments since we do not need to keep running and setting up SCA tools every time.