### PR TITLE
Show enrichment summary for cataloged SBOMs

### DIFF
--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -6,6 +6,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/protobom/protobom/pkg/formats"
+	"github.com/protobom/protobom/pkg/sbom"
+	"github.com/protobom/protobom/pkg/writer"
 )
 
 func TestRunGenerateStdoutAndStderrSeparation(t *testing.T) {
@@ -19,6 +23,7 @@ func TestRunGenerateStdoutAndStderrSeparation(t *testing.T) {
 	authors = nil
 	attestationTypes = []string{"material", "command-run", "product", "network-trace"}
 	catalog = ""
+	catalogFile = ""
 	projectDir = ""
 	skipPaths = nil
 	summaryFlag = false
@@ -43,6 +48,9 @@ func TestRunGenerateStdoutAndStderrSeparation(t *testing.T) {
 	if strings.Contains(stderr, "    - pkg:") {
 		t.Fatalf("did not expect detailed package listing without --summary: %s", stderr)
 	}
+	if strings.Contains(stderr, "SBOMit Enrichment Summary") {
+		t.Fatalf("did not expect enrichment summary without a base catalog, got: %s", stderr)
+	}
 }
 
 func TestRunGenerateDetailedSummaryToStderrWithFileOutput(t *testing.T) {
@@ -59,6 +67,7 @@ func TestRunGenerateDetailedSummaryToStderrWithFileOutput(t *testing.T) {
 	authors = nil
 	attestationTypes = []string{"material", "command-run", "product", "network-trace"}
 	catalog = ""
+	catalogFile = ""
 	projectDir = ""
 	skipPaths = nil
 	summaryFlag = true
@@ -90,6 +99,46 @@ func TestRunGenerateDetailedSummaryToStderrWithFileOutput(t *testing.T) {
 	}
 }
 
+func TestRunGeneratePrintsEnrichmentSummaryWithCatalogFile(t *testing.T) {
+	restore := snapshotGenerateGlobals()
+	defer restore()
+
+	tmpDir := t.TempDir()
+	catalogPath := filepath.Join(tmpDir, "catalog.spdx.json")
+	target := filepath.Join(tmpDir, "sbom.json")
+	writeTestCatalog(t, catalogPath)
+
+	outputPath = target
+	outputFormat = "spdx23"
+	documentName = "sbomit-sbom"
+	documentVersion = "0.0.1"
+	authors = nil
+	attestationTypes = []string{"material", "command-run", "product", "network-trace"}
+	catalog = ""
+	catalogFile = catalogPath
+	projectDir = ""
+	skipPaths = nil
+	summaryFlag = false
+
+	stdout, stderr, err := captureGenerateOutput(t, filepath.Join("..", "test", "sample-attestation.json"))
+	if err != nil {
+		t.Fatalf("runGenerate returned error: %v", err)
+	}
+
+	if stdout != "" {
+		t.Fatalf("expected no stdout when writing SBOM to file, got: %s", stdout)
+	}
+	if !strings.Contains(stderr, "SBOMit Enrichment Summary") {
+		t.Fatalf("expected enrichment summary on stderr, got: %s", stderr)
+	}
+	if !strings.Contains(stderr, "Base Packages: 1") {
+		t.Fatalf("expected base package count in enrichment summary, got: %s", stderr)
+	}
+	if !strings.Contains(stderr, "SBOM Summary") {
+		t.Fatalf("expected existing SBOM summary to remain on stderr, got: %s", stderr)
+	}
+}
+
 func snapshotGenerateGlobals() func() {
 	prevOutputPath := outputPath
 	prevOutputFormat := outputFormat
@@ -98,6 +147,7 @@ func snapshotGenerateGlobals() func() {
 	prevAuthors := append([]string(nil), authors...)
 	prevAttestationTypes := append([]string(nil), attestationTypes...)
 	prevCatalog := catalog
+	prevCatalogFile := catalogFile
 	prevProjectDir := projectDir
 	prevSkipPaths := append([]string(nil), skipPaths...)
 	prevSummaryFlag := summaryFlag
@@ -110,6 +160,7 @@ func snapshotGenerateGlobals() func() {
 		authors = prevAuthors
 		attestationTypes = prevAttestationTypes
 		catalog = prevCatalog
+		catalogFile = prevCatalogFile
 		projectDir = prevProjectDir
 		skipPaths = prevSkipPaths
 		summaryFlag = prevSummaryFlag
@@ -181,4 +232,26 @@ func readAllPipe(f *os.File) ([]byte, error) {
 	var buf bytes.Buffer
 	_, err := buf.ReadFrom(f)
 	return buf.Bytes(), err
+}
+
+func writeTestCatalog(t *testing.T, path string) {
+	t.Helper()
+
+	catalogDoc := sbom.NewDocument()
+	catalogDoc.Metadata.Id = "urn:uuid:test-catalog"
+	catalogDoc.Metadata.Name = "catalog"
+	catalogDoc.NodeList.AddRootNode(&sbom.Node{Id: "catalog-root"})
+	catalogDoc.NodeList.AddNode(&sbom.Node{
+		Id:      "pkg:generic/catalog-package@1.0.0",
+		Type:    sbom.Node_PACKAGE,
+		Name:    "catalog-package",
+		Version: "1.0.0",
+		Identifiers: map[int32]string{
+			int32(sbom.SoftwareIdentifierType_PURL): "pkg:generic/catalog-package@1.0.0",
+		},
+	})
+
+	if err := writer.New().WriteFileWithOptions(catalogDoc, path, &writer.Options{Format: formats.SPDX23JSON}); err != nil {
+		t.Fatalf("write catalog SBOM: %v", err)
+	}
 }

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -368,7 +368,7 @@ func (g *Generator) mergePreferAttestation(baseDoc *sbom.Document, attDoc *sbom.
 		}
 
 		if targetNode != nil {
-			if shouldTrackEnrichment(attNode, attRoots) &&
+			if isNonRootPackage(attNode, attRoots) &&
 				originalBaseNodes[targetNode] &&
 				!enrichedBaseNodes[targetNode] &&
 				hasPackageEnrichment(targetNode, attNode) {
@@ -388,7 +388,7 @@ func (g *Generator) mergePreferAttestation(baseDoc *sbom.Document, attDoc *sbom.
 			if key := normalizedPURLKey(attPurl); key != "" {
 				baseIndexByPURL[key] = attNode
 			}
-			if shouldTrackEnrichment(attNode, attRoots) {
+			if isNonRootPackage(attNode, attRoots) {
 				summary.AddedPackages++
 			}
 		}
@@ -403,33 +403,17 @@ func (g *Generator) mergePreferAttestation(baseDoc *sbom.Document, attDoc *sbom.
 	return summary
 }
 
-func rootElementSet(doc *sbom.Document) map[string]bool {
-	roots := map[string]bool{}
-	if doc == nil || doc.NodeList == nil {
-		return roots
-	}
-	for _, id := range doc.NodeList.RootElements {
-		roots[id] = true
-	}
-	return roots
-}
-
 func countPackageNodes(doc *sbom.Document, roots map[string]bool) int {
 	if doc == nil || doc.NodeList == nil {
 		return 0
 	}
-
 	total := 0
 	for _, node := range doc.NodeList.Nodes {
-		if node != nil && node.Type == sbom.Node_PACKAGE && !roots[node.Id] {
+		if isNonRootPackage(node, roots) {
 			total++
 		}
 	}
 	return total
-}
-
-func shouldTrackEnrichment(node *sbom.Node, roots map[string]bool) bool {
-	return node != nil && node.Type == sbom.Node_PACKAGE && !roots[node.Id]
 }
 
 func normalizedPURLKey(purl string) string {

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -157,7 +157,8 @@ func (g *Generator) GenerateFromAttestations(attestations []attestation.TypedAtt
 
 	if baseDoc != nil {
 		g.applyMetadata(baseDoc)
-		g.mergePreferAttestation(baseDoc, attDoc)
+		enrichment := g.mergePreferAttestation(baseDoc, attDoc)
+		WriteEnrichmentSummary(os.Stderr, enrichment)
 		err = g.writeOutput(baseDoc)
 		return baseDoc, err
 	}
@@ -315,24 +316,31 @@ func (g *Generator) applyMetadata(doc *sbom.Document) {
 	})
 }
 
-func (g *Generator) mergePreferAttestation(baseDoc *sbom.Document, attDoc *sbom.Document) {
+func (g *Generator) mergePreferAttestation(baseDoc *sbom.Document, attDoc *sbom.Document) EnrichmentSummary {
+	summary := EnrichmentSummary{}
 	if baseDoc == nil || baseDoc.NodeList == nil || attDoc == nil || attDoc.NodeList == nil {
-		return
+		return summary
 	}
 
-	// Index syft nodes by both ID and PURL for deduplication
+	baseRoots := rootElementSet(baseDoc)
+	attRoots := rootElementSet(attDoc)
+	summary.BasePackages = countPackageNodes(baseDoc, baseRoots)
+
+	// Index catalog nodes by both ID and normalized PURL for deduplication.
 	baseIndexByID := map[string]*sbom.Node{}
 	baseIndexByPURL := map[string]*sbom.Node{}
+	originalBaseNodes := map[*sbom.Node]bool{}
+	enrichedBaseNodes := map[*sbom.Node]bool{}
 
 	for _, node := range baseDoc.NodeList.Nodes {
 		if node == nil || node.Id == "" {
 			continue
 		}
 		baseIndexByID[node.Id] = node
+		originalBaseNodes[node] = true
 
-		purl := string(node.Purl())
-		if purl != "" {
-			baseIndexByPURL[strings.ToLower(purl)] = node
+		if key := normalizedPURLKey(string(node.Purl())); key != "" {
+			baseIndexByPURL[key] = node
 		}
 	}
 
@@ -346,8 +354,8 @@ func (g *Generator) mergePreferAttestation(baseDoc *sbom.Document, attDoc *sbom.
 
 		// First try to match by PURL (this handles different ID schemes)
 		attPurl := string(attNode.Purl())
-		if attPurl != "" {
-			if baseNode, ok := baseIndexByPURL[strings.ToLower(attPurl)]; ok {
+		if attPurlKey := normalizedPURLKey(attPurl); attPurlKey != "" {
+			if baseNode, ok := baseIndexByPURL[attPurlKey]; ok {
 				targetNode = baseNode
 			}
 		}
@@ -360,14 +368,28 @@ func (g *Generator) mergePreferAttestation(baseDoc *sbom.Document, attDoc *sbom.
 		}
 
 		if targetNode != nil {
-			// Merge: prefer attestation values over syft
+			if shouldTrackEnrichment(attNode, attRoots) &&
+				originalBaseNodes[targetNode] &&
+				!enrichedBaseNodes[targetNode] &&
+				hasPackageEnrichment(targetNode, attNode) {
+				summary.EnrichedPackages++
+				enrichedBaseNodes[targetNode] = true
+			}
+
+			// Merge: prefer attestation values over cataloger values.
 			targetNode.Update(attNode)
+			if key := normalizedPURLKey(string(targetNode.Purl())); key != "" {
+				baseIndexByPURL[key] = targetNode
+			}
 		} else {
 			// New node from attestation
 			baseDoc.NodeList.AddNode(attNode)
 			baseIndexByID[attNode.Id] = attNode
-			if attPurl != "" {
-				baseIndexByPURL[strings.ToLower(attPurl)] = attNode
+			if key := normalizedPURLKey(attPurl); key != "" {
+				baseIndexByPURL[key] = attNode
+			}
+			if shouldTrackEnrichment(attNode, attRoots) {
+				summary.AddedPackages++
 			}
 		}
 	}
@@ -377,6 +399,62 @@ func (g *Generator) mergePreferAttestation(baseDoc *sbom.Document, attDoc *sbom.
 	mergeList.Edges = attDoc.NodeList.Edges
 	mergeList.RootElements = attDoc.NodeList.RootElements
 	baseDoc.NodeList.Add(mergeList)
+
+	return summary
+}
+
+func rootElementSet(doc *sbom.Document) map[string]bool {
+	roots := map[string]bool{}
+	if doc == nil || doc.NodeList == nil {
+		return roots
+	}
+	for _, id := range doc.NodeList.RootElements {
+		roots[id] = true
+	}
+	return roots
+}
+
+func countPackageNodes(doc *sbom.Document, roots map[string]bool) int {
+	if doc == nil || doc.NodeList == nil {
+		return 0
+	}
+
+	total := 0
+	for _, node := range doc.NodeList.Nodes {
+		if node != nil && node.Type == sbom.Node_PACKAGE && !roots[node.Id] {
+			total++
+		}
+	}
+	return total
+}
+
+func shouldTrackEnrichment(node *sbom.Node, roots map[string]bool) bool {
+	return node != nil && node.Type == sbom.Node_PACKAGE && !roots[node.Id]
+}
+
+func normalizedPURLKey(purl string) string {
+	if purl == "" {
+		return ""
+	}
+	base, _, _ := strings.Cut(purl, "?")
+	return strings.ToLower(base)
+}
+
+func hasPackageEnrichment(baseNode, attNode *sbom.Node) bool {
+	for algo, hash := range attNode.Hashes {
+		if baseHash, ok := baseNode.Hashes[algo]; !ok || baseHash != hash {
+			return true
+		}
+	}
+
+	for idType, identifier := range attNode.Identifiers {
+		baseIdentifier, ok := baseNode.Identifiers[idType]
+		if !ok || baseIdentifier != identifier {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (g *Generator) readCatalogFile(path string) (*sbom.Document, error) {

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -58,3 +58,81 @@ func TestGenerateFromAttestationsCanUseCatalogFile(t *testing.T) {
 
 	t.Fatal("catalog package was not preserved")
 }
+
+func TestMergePreferAttestationTracksAddedPackages(t *testing.T) {
+	baseDoc := sbom.NewDocument()
+	baseDoc.NodeList.AddRootNode(&sbom.Node{Id: "catalog-root"})
+	baseDoc.NodeList.AddNode(testPackageNode("pkg:generic/base@1.0.0"))
+
+	attDoc := sbom.NewDocument()
+	attDoc.NodeList.AddRootNode(&sbom.Node{Id: "attestation-root"})
+	attDoc.NodeList.AddNode(testPackageNode("pkg:generic/added@1.0.0"))
+
+	summary := New(DefaultOptions()).mergePreferAttestation(baseDoc, attDoc)
+
+	if summary.BasePackages != 1 {
+		t.Fatalf("expected 1 base package, got %d", summary.BasePackages)
+	}
+	if summary.AddedPackages != 1 {
+		t.Fatalf("expected 1 added package, got %d", summary.AddedPackages)
+	}
+	if summary.EnrichedPackages != 0 {
+		t.Fatalf("expected 0 enriched packages, got %d", summary.EnrichedPackages)
+	}
+}
+
+func TestMergePreferAttestationTracksEnrichedPackages(t *testing.T) {
+	baseDoc := sbom.NewDocument()
+	baseDoc.NodeList.AddNode(testPackageNode("pkg:generic/base@1.0.0"))
+
+	attNode := testPackageNode("pkg:generic/base@1.0.0")
+	attNode.Hashes = map[int32]string{
+		int32(sbom.HashAlgorithm_SHA256): "abc123",
+	}
+	attDoc := sbom.NewDocument()
+	attDoc.NodeList.AddNode(attNode)
+
+	summary := New(DefaultOptions()).mergePreferAttestation(baseDoc, attDoc)
+
+	if summary.AddedPackages != 0 {
+		t.Fatalf("expected 0 added packages, got %d", summary.AddedPackages)
+	}
+	if summary.EnrichedPackages != 1 {
+		t.Fatalf("expected 1 enriched package, got %d", summary.EnrichedPackages)
+	}
+	if got := baseDoc.NodeList.Nodes[0].Hashes[int32(sbom.HashAlgorithm_SHA256)]; got != "abc123" {
+		t.Fatalf("expected hash to be merged into base package, got %q", got)
+	}
+}
+
+func TestMergePreferAttestationMatchesQualifiedPURLAsEnrichment(t *testing.T) {
+	baseDoc := sbom.NewDocument()
+	baseDoc.NodeList.AddNode(testPackageNode("pkg:pypi/certifi@2025.11.12"))
+
+	attDoc := sbom.NewDocument()
+	attDoc.NodeList.AddNode(testPackageNode("pkg:pypi/certifi@2025.11.12?url=https://files.pythonhosted.org/certifi.whl"))
+
+	summary := New(DefaultOptions()).mergePreferAttestation(baseDoc, attDoc)
+
+	if summary.AddedPackages != 0 {
+		t.Fatalf("expected qualified PURL to match existing package, got %d added packages", summary.AddedPackages)
+	}
+	if summary.EnrichedPackages != 1 {
+		t.Fatalf("expected qualified PURL to enrich existing package, got %d", summary.EnrichedPackages)
+	}
+	if got := countPackageNodes(baseDoc, rootElementSet(baseDoc)); got != 1 {
+		t.Fatalf("expected no duplicate package after qualified PURL merge, got %d packages", got)
+	}
+}
+
+func testPackageNode(purl string) *sbom.Node {
+	return &sbom.Node{
+		Id:      purl,
+		Type:    sbom.Node_PACKAGE,
+		Name:    purl,
+		Version: "1.0.0",
+		Identifiers: map[int32]string{
+			int32(sbom.SoftwareIdentifierType_PURL): purl,
+		},
+	}
+}

--- a/pkg/generator/summary.go
+++ b/pkg/generator/summary.go
@@ -15,6 +15,12 @@ type Summary struct {
 	PackagesByEcosystem map[string][]string
 }
 
+type EnrichmentSummary struct {
+	BasePackages     int
+	AddedPackages    int
+	EnrichedPackages int
+}
+
 func GenerateSummary(doc *sbom.Document) Summary {
 	summary := Summary{
 		PackagesByEcosystem: make(map[string][]string),
@@ -92,4 +98,12 @@ func WriteSummary(w io.Writer, summary Summary, detailed bool) {
 			fmt.Fprintf(w, "    - %s\n", item)
 		}
 	}
+}
+
+func WriteEnrichmentSummary(w io.Writer, summary EnrichmentSummary) {
+	fmt.Fprintln(w, "SBOMit Enrichment Summary")
+	fmt.Fprintf(w, "Base Packages: %d\n", summary.BasePackages)
+	fmt.Fprintf(w, "Added by Attestation: %d\n", summary.AddedPackages)
+	fmt.Fprintf(w, "Enriched Packages: %d\n", summary.EnrichedPackages)
+	fmt.Fprintln(w)
 }

--- a/pkg/generator/summary.go
+++ b/pkg/generator/summary.go
@@ -21,6 +21,28 @@ type EnrichmentSummary struct {
 	EnrichedPackages int
 }
 
+// rootElementSet returns a set of root-element IDs for a document so that
+// synthetic top-level nodes (e.g. the application node added by sbomit) can be
+// excluded from package counts and ecosystem breakdowns.
+func rootElementSet(doc *sbom.Document) map[string]bool {
+	roots := map[string]bool{}
+	if doc == nil || doc.NodeList == nil {
+		return roots
+	}
+	for _, id := range doc.NodeList.RootElements {
+		roots[id] = true
+	}
+	return roots
+}
+
+// isNonRootPackage reports whether node is a real package node that should be
+// counted — i.e. it is a PACKAGE node whose ID does not appear in roots.
+// This single predicate is the one canonical check used by GenerateSummary,
+// countPackageNodes, and shouldTrackEnrichment.
+func isNonRootPackage(node *sbom.Node, roots map[string]bool) bool {
+	return node != nil && node.Type == sbom.Node_PACKAGE && !roots[node.Id]
+}
+
 func GenerateSummary(doc *sbom.Document) Summary {
 	summary := Summary{
 		PackagesByEcosystem: make(map[string][]string),
@@ -30,13 +52,10 @@ func GenerateSummary(doc *sbom.Document) Summary {
 		return summary
 	}
 
-	rootElements := make(map[string]bool, len(doc.NodeList.RootElements))
-	for _, id := range doc.NodeList.RootElements {
-		rootElements[id] = true
-	}
+	roots := rootElementSet(doc)
 
 	for _, node := range doc.NodeList.Nodes {
-		if rootElements[node.Id] {
+		if roots[node.Id] {
 			continue
 		}
 		switch node.Type {

--- a/pkg/generator/summary.go
+++ b/pkg/generator/summary.go
@@ -37,8 +37,6 @@ func rootElementSet(doc *sbom.Document) map[string]bool {
 
 // isNonRootPackage reports whether node is a real package node that should be
 // counted — i.e. it is a PACKAGE node whose ID does not appear in roots.
-// This single predicate is the one canonical check used by GenerateSummary,
-// countPackageNodes, and shouldTrackEnrichment.
 func isNonRootPackage(node *sbom.Node, roots map[string]bool) bool {
 	return node != nil && node.Type == sbom.Node_PACKAGE && !roots[node.Id]
 }


### PR DESCRIPTION
Closes #25

This adds an enrichment summary when SBOMit merges attestation data into a base SBOM from Syft Trivy or a catalog file.

The change follows Abhi's feedback on PR #24 by reusing the existing merge path instead of adding a separate diff package. The merge now counts base packages before enrichment then tracks packages that were added from attestations and packages that received new attestation metadata during the merge.

This also improves PURL matching so a package with URL qualifiers from attestation data updates the existing catalog package instead of becoming a duplicate package.

This replaces PR #24 with a fresh branch from current master.

Validation completed locally with go test all packages go vet all packages gofmt on changed files and make build.