### PR TITLE
fix: generate valid UUID v4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/sbomit/sbomit
 go 1.22.0
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/protobom/protobom v0.4.2
 	github.com/spf13/cobra v1.8.0
 	google.golang.org/protobuf v1.34.1
@@ -14,7 +15,6 @@ require (
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spdx/tools-golang v0.5.4 // indirect

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/protobom/protobom/pkg/formats"
 	"github.com/protobom/protobom/pkg/reader"
 	"github.com/protobom/protobom/pkg/sbom"
@@ -562,12 +563,5 @@ func sanitizeID(s string) string {
 }
 
 func generateUUID() string {
-	now := time.Now().UnixNano()
-	return fmt.Sprintf("%x-%x-%x-%x-%x",
-		now&0xFFFFFFFF,
-		(now>>32)&0xFFFF,
-		(now>>48)&0xFFFF,
-		(now>>16)&0xFFFF,
-		now&0xFFFFFFFFFFFF,
-	)
+	return uuid.NewString()
 }


### PR DESCRIPTION
Fixes #35

This PR replaces the custom time-based UUID generation with github.com/google/uuid to generate valid UUID v4 values.

Tests:
- go test ./...