### PR TITLE
fix: support npm/yarn layouts in JavaScript dependency resolver

### DIFF
--- a/pkg/resolver/javascript.go
+++ b/pkg/resolver/javascript.go
@@ -12,6 +12,8 @@ type JavaScriptResolver struct {
 
 func NewJavaScriptResolver() *JavaScriptResolver {
 	return &JavaScriptResolver{
+		// pnpm virtual store layout:
+		//   node_modules/.pnpm/<name>@<version>(<peers>)/node_modules/<name>/...
 		pnpmPathRe: regexp.MustCompile(`node_modules/\.pnpm/([^/]+)/node_modules/(@[^/]+/[^/]+|[^/]+)(?:/|$)`),
 	}
 }
@@ -21,7 +23,8 @@ func (r *JavaScriptResolver) Name() string {
 }
 
 func (r *JavaScriptResolver) Resolve(files []FileInfo) (packages []PackageInfo, remainingFiles []FileInfo) {
-	seen := make(map[string]struct{})
+	byKey := make(map[string]*PackageInfo)
+	order := []string{}
 
 	for _, f := range files {
 		np := path.Clean(f.Path)
@@ -31,7 +34,7 @@ func (r *JavaScriptResolver) Resolve(files []FileInfo) (packages []PackageInfo, 
 			continue
 		}
 
-		name, version, ok := r.extractPnpmPackage(np)
+		name, version, ok := r.extractPackage(np)
 		if !ok {
 			remainingFiles = append(remainingFiles, f)
 			continue
@@ -39,21 +42,26 @@ func (r *JavaScriptResolver) Resolve(files []FileInfo) (packages []PackageInfo, 
 
 		name = NormalizeNpmPackageName(name)
 		key := name + "@" + version
-		if _, ok := seen[key]; ok {
-			continue
+		pkg, ok := byKey[key]
+		if !ok {
+			pkg = &PackageInfo{
+				Name:      name,
+				Version:   version,
+				Ecosystem: "npm",
+				PURL:      npmPURL(name, version),
+				FoundBy:   "attestation:javascript",
+			}
+			byKey[key] = pkg
+			order = append(order, key)
 		}
-		seen[key] = struct{}{}
 
-		purl := "pkg:npm/" + name + "@" + version
-		pkg := PackageInfo{
-			Name:      name,
-			Version:   version,
-			Ecosystem: "npm",
-			PURL:      purl,
-			Hashes:    f.Hashes,
-			FoundBy:   "attestation:javascript",
+		if len(pkg.Hashes) == 0 && len(f.Hashes) > 0 {
+			pkg.Hashes = f.Hashes
 		}
-		packages = append(packages, pkg)
+	}
+
+	for _, key := range order {
+		packages = append(packages, *byKey[key])
 	}
 
 	return packages, remainingFiles
@@ -85,31 +93,49 @@ func (f *jsPackageFilter) Matches(p string) bool {
 	np := path.Clean(p)
 	npLower := strings.ToLower(np)
 
-	if !strings.Contains(npLower, "/node_modules/.pnpm/") {
+	if !strings.Contains(npLower, "node_modules/") {
 		return false
 	}
 
 	name := strings.ToLower(f.packageName)
-	ver := strings.ToLower(f.version)
-	if name == "" || ver == "" {
+	if name == "" {
 		return false
 	}
 
-	pnpmName := strings.ReplaceAll(name, "/", "+")
-	if strings.HasPrefix(pnpmName, "@") {
-		pnpmName = "@" + strings.TrimPrefix(pnpmName, "@")
+	// Inside a pnpm virtual store, match on the versioned store directory
+	// so multiple versions of the same package do not cross-match.
+	if strings.Contains(npLower, "/node_modules/.pnpm/") {
+		ver := strings.ToLower(f.version)
+		if ver == "" {
+			return false
+		}
+
+		// Scoped separators become '+' in pnpm store directory names.
+		pnpmName := strings.ReplaceAll(name, "/", "+")
+
+		return strings.Contains(npLower, "/node_modules/.pnpm/"+pnpmName+"@"+ver)
 	}
 
-	if strings.Contains(npLower, "/node_modules/.pnpm/"+pnpmName+"@"+ver) &&
-		strings.Contains(npLower, "/node_modules/"+name+"/") {
-		return true
-	}
-
-	return false
+	return nodeModulesPathContainsPackage(npLower, name)
 }
 
 func (r *JavaScriptResolver) isJavaScriptPath(p string) bool {
 	return strings.Contains(p, "node_modules") || strings.Contains(p, ".pnpm")
+}
+
+// extractPackage resolves the package a path belongs to based on its layout.
+//
+// Two topologies are supported:
+//   - pnpm: node_modules/.pnpm/<name>@<version>(<peers>)/node_modules/<name>/...
+//     where the version is encoded in the virtual-store directory name.
+//   - npm/yarn classic: node_modules/<name>/... or node_modules/@scope/<name>/...
+//     where versions are not part of the path, so packages are reported
+//     unversioned and can be enriched later by merging cataloger output.
+func (r *JavaScriptResolver) extractPackage(p string) (string, string, bool) {
+	if strings.Contains(p, "/node_modules/.pnpm/") {
+		return r.extractPnpmPackage(p)
+	}
+	return r.extractNodeModulesPackage(p)
 }
 
 func (r *JavaScriptResolver) extractPnpmPackage(p string) (string, string, bool) {
@@ -120,12 +146,46 @@ func (r *JavaScriptResolver) extractPnpmPackage(p string) (string, string, bool)
 
 	segment := matches[1]
 	name := matches[2]
+	if isNodeModulesInternalEntry(name) {
+		return "", "", false
+	}
+
 	version := extractPnpmVersion(segment)
 	if version == "" {
 		return "", "", false
 	}
 
 	return name, version, true
+}
+
+func (r *JavaScriptResolver) extractNodeModulesPackage(p string) (string, string, bool) {
+	segments := strings.Split(p, "/")
+
+	// Walk from the innermost segment outward so nested layouts such as
+	// node_modules/<parent>/node_modules/<child>/... resolve to <child>.
+	for i := len(segments) - 2; i >= 0; i-- {
+		if segments[i] != "node_modules" {
+			continue
+		}
+
+		name := segments[i+1]
+		if strings.HasPrefix(name, "@") && i+2 < len(segments) {
+			name = name + "/" + segments[i+2]
+		}
+
+		if name == "" || isNodeModulesInternalEntry(name) {
+			continue
+		}
+
+		// Standard npm/yarn layouts do not encode versions in paths.
+		return name, "", true
+	}
+
+	return "", "", false
+}
+
+func isNodeModulesInternalEntry(name string) bool {
+	return strings.HasPrefix(name, ".")
 }
 
 func extractPnpmVersion(segment string) string {
@@ -144,6 +204,18 @@ func extractPnpmVersion(segment string) string {
 	}
 
 	return segment[lastAt+1:]
+}
+
+// npmPURL builds an npm PURL, omitting the version component when unknown.
+func npmPURL(name, version string) string {
+	if version == "" {
+		return "pkg:npm/" + name
+	}
+	return "pkg:npm/" + name + "@" + version
+}
+
+func nodeModulesPathContainsPackage(p, packageName string) bool {
+	return strings.Contains(p, "node_modules/"+packageName+"/")
 }
 
 // NormalizeNpmPackageName lowercases and trims an npm package name.

--- a/pkg/resolver/javascript_test.go
+++ b/pkg/resolver/javascript_test.go
@@ -1,0 +1,234 @@
+package resolver
+
+import "testing"
+
+func TestJavaScriptResolverResolvesPnpmLayout(t *testing.T) {
+	r := NewJavaScriptResolver()
+
+	packages, remaining := r.Resolve([]FileInfo{
+		{Path: "/project/node_modules/.pnpm/lodash@4.17.21/node_modules/lodash/lodash.js"},
+		{Path: "/project/node_modules/.pnpm/@babel+core@7.24.0/node_modules/@babel/core/index.js"},
+	})
+
+	if len(remaining) != 0 {
+		t.Fatalf("expected no remaining files, got %d", len(remaining))
+	}
+	if len(packages) != 2 {
+		t.Fatalf("expected two packages, got %d", len(packages))
+	}
+
+	if packages[0].Name != "lodash" || packages[0].Version != "4.17.21" {
+		t.Fatalf("unexpected package: %s@%s", packages[0].Name, packages[0].Version)
+	}
+	if packages[0].PURL != "pkg:npm/lodash@4.17.21" {
+		t.Fatalf("unexpected PURL: %s", packages[0].PURL)
+	}
+	if packages[1].Name != "@babel/core" || packages[1].Version != "7.24.0" {
+		t.Fatalf("unexpected scoped package: %s@%s", packages[1].Name, packages[1].Version)
+	}
+	if packages[1].PURL != "pkg:npm/@babel/core@7.24.0" {
+		t.Fatalf("unexpected PURL: %s", packages[1].PURL)
+	}
+}
+
+func TestJavaScriptResolverResolvesNpmFlatLayout(t *testing.T) {
+	r := NewJavaScriptResolver()
+
+	packages, remaining := r.Resolve([]FileInfo{
+		{Path: "/project/node_modules/lodash/lodash.js"},
+		{
+			Path: "/project/node_modules/lodash/package.json",
+			Hashes: map[string]string{
+				"sha256": "abc123",
+			},
+		},
+	})
+
+	if len(remaining) != 0 {
+		t.Fatalf("expected no remaining files, got %d", len(remaining))
+	}
+	if len(packages) != 1 {
+		t.Fatalf("expected one package, got %d", len(packages))
+	}
+
+	pkg := packages[0]
+	if pkg.Name != "lodash" {
+		t.Fatalf("unexpected package name: %s", pkg.Name)
+	}
+	if pkg.Version != "" {
+		t.Fatalf("expected empty version for npm layout, got %q", pkg.Version)
+	}
+	if pkg.PURL != "pkg:npm/lodash" {
+		t.Fatalf("unexpected PURL: %s", pkg.PURL)
+	}
+	if pkg.Ecosystem != "npm" || pkg.FoundBy != "attestation:javascript" {
+		t.Fatalf("unexpected package metadata: %#v", pkg)
+	}
+	if len(pkg.Hashes) != 1 {
+		t.Fatalf("expected first file hashes to be promoted, got %#v", pkg.Hashes)
+	}
+}
+
+func TestJavaScriptResolverResolvesScopedPackages(t *testing.T) {
+	r := NewJavaScriptResolver()
+
+	packages, _ := r.Resolve([]FileInfo{
+		{Path: "/project/node_modules/@types/node/fs.d.ts"},
+	})
+
+	if len(packages) != 1 {
+		t.Fatalf("expected one package, got %d", len(packages))
+	}
+	if packages[0].Name != "@types/node" {
+		t.Fatalf("unexpected package name: %s", packages[0].Name)
+	}
+	if packages[0].PURL != "pkg:npm/@types/node" {
+		t.Fatalf("unexpected PURL: %s", packages[0].PURL)
+	}
+}
+
+func TestJavaScriptResolverPrefersInnermostNestedPackage(t *testing.T) {
+	r := NewJavaScriptResolver()
+
+	packages, _ := r.Resolve([]FileInfo{
+		{Path: "/project/node_modules/express/node_modules/lodash/lib.js"},
+	})
+
+	if len(packages) != 1 {
+		t.Fatalf("expected one package, got %d", len(packages))
+	}
+	if packages[0].Name != "lodash" {
+		t.Fatalf("expected innermost package lodash, got %s", packages[0].Name)
+	}
+}
+
+func TestJavaScriptResolverDeduplicatesFilesOfSamePackage(t *testing.T) {
+	r := NewJavaScriptResolver()
+
+	packages, remaining := r.Resolve([]FileInfo{
+		{Path: "/project/node_modules/react/index.js"},
+		{Path: "/project/node_modules/react/jsx-runtime.js"},
+		{Path: "/project/node_modules/react/cjs/react.development.js"},
+	})
+
+	if len(remaining) != 0 {
+		t.Fatalf("expected no remaining files, got %d", len(remaining))
+	}
+	if len(packages) != 1 {
+		t.Fatalf("expected one deduplicated package, got %d", len(packages))
+	}
+}
+
+func TestJavaScriptResolverSkipsNodeModulesInternals(t *testing.T) {
+	r := NewJavaScriptResolver()
+
+	packages, remaining := r.Resolve([]FileInfo{
+		{Path: "/project/node_modules/.bin/mocha"},
+		{Path: "/project/node_modules/.package-lock.json"},
+		{Path: "/project/node_modules/.pnpm/lock.yaml"},
+	})
+
+	if len(packages) != 0 {
+		t.Fatalf("expected no packages from node_modules internals, got %d", len(packages))
+	}
+	if len(remaining) != 3 {
+		t.Fatalf("expected internals to remain unresolved, got %d", len(remaining))
+	}
+}
+
+func TestJavaScriptResolverMixedLayouts(t *testing.T) {
+	r := NewJavaScriptResolver()
+
+	packages, remaining := r.Resolve([]FileInfo{
+		{Path: "/project/node_modules/.pnpm/left-pad@1.3.0/node_modules/left-pad/index.js"},
+		{Path: "/project/node_modules/underscore/underscore.js"},
+		{Path: "/project/node_modules/@scope/util/index.js"},
+	})
+
+	if len(remaining) != 0 {
+		t.Fatalf("expected no remaining files, got %d", len(remaining))
+	}
+	if len(packages) != 3 {
+		t.Fatalf("expected three packages, got %d", len(packages))
+	}
+
+	byPURL := make(map[string]PackageInfo)
+	for _, pkg := range packages {
+		byPURL[pkg.PURL] = pkg
+	}
+
+	versioned, ok := byPURL["pkg:npm/left-pad@1.3.0"]
+	if !ok || versioned.Version != "1.3.0" {
+		t.Fatalf("missing versioned pnpm package: %#v", versioned)
+	}
+	if _, ok := byPURL["pkg:npm/underscore"]; !ok {
+		t.Fatalf("missing unversioned npm package")
+	}
+	if _, ok := byPURL["pkg:npm/@scope/util"]; !ok {
+		t.Fatalf("missing unversioned scoped npm package")
+	}
+}
+
+func TestJavaScriptResolverPassesThroughNonJavaScriptPaths(t *testing.T) {
+	r := NewJavaScriptResolver()
+
+	packages, remaining := r.Resolve([]FileInfo{
+		{Path: "/project/main.go"},
+		{Path: "/project/requirements.txt"},
+	})
+
+	if len(packages) != 0 {
+		t.Fatalf("expected no packages, got %d", len(packages))
+	}
+	if len(remaining) != 2 {
+		t.Fatalf("expected files to pass through, got %d", len(remaining))
+	}
+}
+
+func TestJSPackageFilterMatchesStandardNodeModulesPaths(t *testing.T) {
+	f := &jsPackageFilter{packageName: "lodash"}
+
+	if !f.Matches("/project/node_modules/lodash/lodash.js") {
+		t.Fatal("expected filter to match standard npm layout path")
+	}
+	if f.Matches("/project/node_modules/express/index.js") {
+		t.Fatal("expected filter not to match other packages")
+	}
+	if f.Matches("/project/src/index.js") {
+		t.Fatal("expected filter not to match paths outside node_modules")
+	}
+}
+
+func TestJSPackageFilterMatchesScopedPackagePaths(t *testing.T) {
+	f := &jsPackageFilter{packageName: "@types/node"}
+
+	if !f.Matches("/project/node_modules/@types/node/fs.d.ts") {
+		t.Fatal("expected filter to match scoped package path")
+	}
+	if f.Matches("/project/node_modules/@types/react/index.d.ts") {
+		t.Fatal("expected filter not to match other scoped packages")
+	}
+}
+
+func TestJSPackageFilterRequiresVersionForPnpmStoreMatch(t *testing.T) {
+	unversioned := &jsPackageFilter{packageName: "lodash"}
+	if unversioned.Matches("/project/node_modules/.pnpm/lodash@4.17.21/node_modules/lodash/lodash.js") {
+		t.Fatal("expected unversioned filter not to match pnpm store paths")
+	}
+
+	versioned := &jsPackageFilter{packageName: "lodash", version: "4.17.21"}
+	if !versioned.Matches("/project/node_modules/.pnpm/lodash@4.17.21/node_modules/lodash/lodash.js") {
+		t.Fatal("expected versioned filter to match matching pnpm store path")
+	}
+	if versioned.Matches("/project/node_modules/.pnpm/lodash@1.0.0/node_modules/lodash/lodash.js") {
+		t.Fatal("expected versioned filter not to match different pnpm store version")
+	}
+}
+
+func TestJSPackageFilterMatchesPnpmVirtualStoreWithPeerSuffix(t *testing.T) {
+	f := &jsPackageFilter{packageName: "react", version: "18.2.0"}
+
+	if !f.Matches("/project/node_modules/.pnpm/react@18.2.0(react-dom@18.2.0)/node_modules/react/index.js") {
+		t.Fatal("expected filter to match pnpm store entry with peer suffix")
+	}
+}


### PR DESCRIPTION
Fixes #39

# Description

`JavaScriptResolver` in `pkg/resolver/javascript.go` only matched pnpm virtual-store paths (`node_modules/.pnpm/...`), so dependencies installed with **npm** or **yarn classic** were left as unresolved files in the SBOM instead of being reported as packages.

This PR makes the resolver layout-aware so pnpm, npm, and yarn topologies are all supported.

# Changes Made

`pkg/resolver/javascript.go`:
- **Layout detection**: each path is routed to exactly one extractor — pnpm store paths (`/node_modules/.pnpm/`) go to the existing versioned extractor; standard `node_modules/<pkg>` and scoped `node_modules/@scope/<pkg>` paths go to a new flat extractor.
- **Unversioned packages**: npm/yarn layouts do not encode versions in paths, so packages are reported with an empty version and a PURL without the `@version` component (e.g. `pkg:npm/lodash`). Per the discussion in #39, the missing versions can be enriched later by merging cataloger output (syft/trivy).
- **Nested layouts**: files under `node_modules/<parent>/node_modules/<child>/...` are attributed to the innermost package.
- **Internals skipped**: dot-entries under `node_modules` (`.bin`, `.cache`, `.package-lock.json`, ...) are no longer mistaken for packages.
- **File filter**: `jsPackageFilter` now matches standard `node_modules/<name>/` paths for non-pnpm topologies, while keeping strict versioned matching inside pnpm virtual stores so multiple versions of the same package don't cross-match.
- **Hash aggregation**: package hashes are promoted from the first file that carries them (previously only the very first file was considered).

# Testing

Added `pkg/resolver/javascript_test.go` covering:
- pnpm layout regression (plain + scoped + peer-suffix store dirs)
- npm/yarn flat layout → unversioned package with `pkg:npm/<name>` PURL
- scoped packages (`@types/node`)
- nested `node_modules` innermost-package attribution
- deduplication of many files into one package
- node_modules internals left unresolved
- mixed pnpm + npm projects
- filter behavior for standard/scoped/pnpm-store paths

All tests pass (`make test`), along with `go vet ./...` and `gofmt`.

# Known follow-up

When a cataloger (syft/trivy) base SBOM is used, the merge step matches packages by exact normalized PURL, so unversioned attestation packages (e.g. `pkg:npm/lodash`) won't yet enrich their versioned counterparts (`pkg:npm/lodash@4.17.21`). This enrichment belongs to the SBOM generation work tracked in #38.
