### PR TITLE
fix: take package hashes from the package artifact, not a member file

### DIFF
--- a/pkg/resolver/go.go
+++ b/pkg/resolver/go.go
@@ -43,21 +43,15 @@ func (r *GoResolver) Resolve(files []FileInfo) (packages []PackageInfo, remainin
 
 		module = DecodeGoModulePath(module)
 		key := module + "@" + version
-		pkg, ok := byKey[key]
-		if !ok {
-			pkg = &PackageInfo{
+		if _, ok := byKey[key]; !ok {
+			byKey[key] = &PackageInfo{
 				Name:      module,
 				Version:   version,
 				Ecosystem: "golang",
 				PURL:      "pkg:golang/" + module + "@" + encodeGoPURLVersion(version),
 				FoundBy:   "attestation:go",
 			}
-			byKey[key] = pkg
 			order = append(order, key)
-		}
-
-		if !r.isModuleCachePath(np) && len(pkg.Hashes) == 0 {
-			pkg.Hashes = f.Hashes
 		}
 	}
 
@@ -115,10 +109,6 @@ func (f *goPackageFilter) Matches(p string) bool {
 
 func (r *GoResolver) isGoPath(p string) bool {
 	return strings.Contains(p, "/pkg/mod/")
-}
-
-func (r *GoResolver) isModuleCachePath(p string) bool {
-	return strings.Contains(p, "/pkg/mod/cache/download/")
 }
 
 func (r *GoResolver) extractModuleVersion(p string) (string, string, bool) {

--- a/pkg/resolver/javascript.go
+++ b/pkg/resolver/javascript.go
@@ -50,7 +50,6 @@ func (r *JavaScriptResolver) Resolve(files []FileInfo) (packages []PackageInfo, 
 			Version:   version,
 			Ecosystem: "npm",
 			PURL:      purl,
-			Hashes:    f.Hashes,
 			FoundBy:   "attestation:javascript",
 		}
 		packages = append(packages, pkg)

--- a/pkg/resolver/python.go
+++ b/pkg/resolver/python.go
@@ -53,7 +53,6 @@ func (r *PythonResolver) Resolve(files []FileInfo) (packages []PackageInfo, rema
 				Version:   version,
 				Ecosystem: "pypi",
 				PURL:      purl,
-				Hashes:    f.Hashes,
 				FoundBy:   "attestation:python",
 			}
 			packages = append(packages, pkg)

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -1,19 +1,26 @@
 package resolver
 
 type PackageInfo struct {
-	Name        string            `json:"name"`
-	Version     string            `json:"version"`
-	Ecosystem   string            `json:"ecosystem"` // pypi, golang, cargo, npm, etc.
-	PURL        string            `json:"purl"`
-	Licenses    []string          `json:"licenses,omitempty"`
+	Name      string   `json:"name"`
+	Version   string   `json:"version"`
+	Ecosystem string   `json:"ecosystem"` // pypi, golang, cargo, npm, etc.
+	PURL      string   `json:"purl"`
+	Licenses  []string `json:"licenses,omitempty"`
+	// Hashes should be the digest of the package artifact itself: the wheel,
+	// tarball, crate, or module that was distributed as the package.
+	// It must never hold the digest of an individual file that merely belongs
+	// to the package. A package checksum that is really a member-file checksum
+	// cannot be verified against anything the registry publishes.
+
 	Hashes      map[string]string `json:"hashes,omitempty"`
-	FoundBy     string            `json:"found_by"` // which resolver found this
+	FoundBy     string            `json:"found_by"`               // which resolver found this
 	DownloadURL string            `json:"download_url,omitempty"` // set by network resolvers
 	DownloadIP  string            `json:"download_ip,omitempty"`  // set by network resolvers
 }
 
 type FileInfo struct {
-	Path   string            `json:"path"`
+	Path string `json:"path"`
+	// File digests stay on file nodes.
 	Hashes map[string]string `json:"hashes,omitempty"`
 }
 


### PR DESCRIPTION
Fixes #65 

Package checksums were being filled in with the digest of one arbitrary file that belongs to the package, which isn't a digest of the package at all. On `test/orjson_witness.json` that produced 51 of 90 packages with a bogus checksum. pillow, cycler and gunicorn all shared a single value, and httpx carried the digest of an empty file.

A package node now carries a genuine package artifact digest or none at all.
File digests stay on file nodes.