### PR TITLE
pkg/generator: add Validate() to Options

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/sbomit/sbomit/pkg/generator"
 	"github.com/spf13/cobra"
@@ -72,29 +71,6 @@ func runGenerate(attestationFile string) error {
 		return fmt.Errorf("attestation file not found: %s", attestationFile)
 	}
 
-	validFormats := map[string]bool{
-		"spdx23": true, "spdx22": true, "cdx14": true, "cdx15": true,
-		"spdx-2.3": true, "spdx-2.2": true, "cdx-1.4": true, "cdx-1.5": true,
-	}
-	if !validFormats[strings.ToLower(outputFormat)] {
-		return fmt.Errorf("invalid output format: %s (supported: spdx23, spdx22, cdx14, cdx15)", outputFormat)
-	}
-
-	validCatalogs := map[string]bool{
-		"": true, "syft": true, "trivy": true,
-	}
-	if !validCatalogs[strings.ToLower(catalog)] {
-		return fmt.Errorf("invalid catalog: %s (supported: syft, trivy)", catalog)
-	}
-	if catalog != "" && catalogFile != "" {
-		return fmt.Errorf("--catalog and --catalog-file cannot be used together")
-	}
-	if catalogFile != "" {
-		if _, err := os.Stat(catalogFile); os.IsNotExist(err) {
-			return fmt.Errorf("catalog file not found: %s", catalogFile)
-		}
-	}
-
 	opts := &generator.Options{
 		DocumentName:     documentName,
 		DocumentVersion:  documentVersion,
@@ -106,6 +82,18 @@ func runGenerate(attestationFile string) error {
 		CatalogFile:      catalogFile,
 		ProjectDir:       projectDir,
 		SkipPaths:        skipPaths,
+	}
+
+	if err := opts.Validate(); err != nil {
+		return err
+	}
+
+	// File-existence check stays here: it is a CLI UX concern (fast failure
+	// before any processing) rather than pure option validation.
+	if catalogFile != "" {
+		if _, err := os.Stat(catalogFile); os.IsNotExist(err) {
+			return fmt.Errorf("catalog file not found: %s", catalogFile)
+		}
 	}
 
 	gen := generator.New(opts)

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -12,6 +12,40 @@ import (
 	"github.com/protobom/protobom/pkg/writer"
 )
 
+func TestRunGenerateRejectsInvalidFormat(t *testing.T) {
+	restore := snapshotGenerateGlobals()
+	defer restore()
+
+	outputFormat = "xml"
+	catalog = ""
+	catalogFile = ""
+
+	err := runGenerate(filepath.Join("..", "test", "sample-attestation.json"))
+	if err == nil {
+		t.Fatal("expected error for invalid format, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid output format") {
+		t.Fatalf("expected 'invalid output format' in error, got: %v", err)
+	}
+}
+
+func TestRunGenerateRejectsInvalidCatalog(t *testing.T) {
+	restore := snapshotGenerateGlobals()
+	defer restore()
+
+	outputFormat = "spdx23"
+	catalog = "grype"
+	catalogFile = ""
+
+	err := runGenerate(filepath.Join("..", "test", "sample-attestation.json"))
+	if err == nil {
+		t.Fatal("expected error for invalid catalog, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid catalog") {
+		t.Fatalf("expected 'invalid catalog' in error, got: %v", err)
+	}
+}
+
 func TestRunGenerateStdoutAndStderrSeparation(t *testing.T) {
 	restore := snapshotGenerateGlobals()
 	defer restore()

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -35,6 +35,17 @@ type Options struct {
 	SkipPaths        []string
 }
 
+// ValidFormats is the set of recognised OutputFormat values.
+var ValidFormats = map[string]bool{
+	"spdx23": true, "spdx22": true, "cdx14": true, "cdx15": true,
+	"spdx-2.3": true, "spdx-2.2": true, "cdx-1.4": true, "cdx-1.5": true,
+}
+
+// ValidCatalogs is the set of recognised Catalog values (empty string = no catalog).
+var ValidCatalogs = map[string]bool{
+	"": true, "syft": true, "trivy": true,
+}
+
 // DefaultOptions returns default generator options
 func DefaultOptions() *Options {
 	return &Options{
@@ -48,6 +59,22 @@ func DefaultOptions() *Options {
 		ProjectDir:       "",
 		SkipPaths:        []string{},
 	}
+}
+
+// Validate checks that the Options fields are self-consistent and supported.
+// Library callers should invoke this before generator.New(opts) to get a clear
+// error rather than silent fallback to defaults.
+func (o *Options) Validate() error {
+	if !ValidFormats[strings.ToLower(o.OutputFormat)] {
+		return fmt.Errorf("invalid output format %q (supported: spdx23, spdx22, cdx14, cdx15)", o.OutputFormat)
+	}
+	if !ValidCatalogs[strings.ToLower(o.Catalog)] {
+		return fmt.Errorf("invalid catalog %q (supported: syft, trivy)", o.Catalog)
+	}
+	if o.Catalog != "" && o.CatalogFile != "" {
+		return fmt.Errorf("Catalog and CatalogFile cannot both be set")
+	}
+	return nil
 }
 
 type Generator struct {

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -1,12 +1,75 @@
 package generator
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/protobom/protobom/pkg/formats"
 	"github.com/protobom/protobom/pkg/sbom"
 	"github.com/protobom/protobom/pkg/writer"
 )
+
+func TestOptionsValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		opts        Options
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "valid defaults",
+			opts: Options{OutputFormat: "spdx23", Catalog: ""},
+		},
+		{
+			name: "valid uppercase format alias",
+			opts: Options{OutputFormat: "CDX15", Catalog: ""},
+		},
+		{
+			name: "valid cdx alias with dash",
+			opts: Options{OutputFormat: "cdx-1.5", Catalog: "trivy"},
+		},
+		{
+			name: "valid syft catalog",
+			opts: Options{OutputFormat: "spdx22", Catalog: "syft"},
+		},
+		{
+			name:        "invalid output format",
+			opts:        Options{OutputFormat: "xml", Catalog: ""},
+			wantErr:     true,
+			errContains: "invalid output format",
+		},
+		{
+			name:        "invalid catalog",
+			opts:        Options{OutputFormat: "spdx23", Catalog: "grype"},
+			wantErr:     true,
+			errContains: "invalid catalog",
+		},
+		{
+			name:        "catalog and catalogFile both set",
+			opts:        Options{OutputFormat: "spdx23", Catalog: "syft", CatalogFile: "/some/file.json"},
+			wantErr:     true,
+			errContains: "cannot both be set",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.opts.Validate()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tc.errContains != "" && !strings.Contains(err.Error(), tc.errContains) {
+					t.Fatalf("expected error containing %q, got: %v", tc.errContains, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("expected no error, got: %v", err)
+				}
+			}
+		})
+	}
+}
 
 func TestGenerateFromAttestationsCanUseCatalogFile(t *testing.T) {
 	tmp := t.TempDir()


### PR DESCRIPTION
Fixes #69 Part of #62.

Format and catalog validation only happened in `cmd/generate.go`. A library caller who built `generator.Options` directly got no error for an invalid `OutputFormat` or `Catalog` value as the generator silently fell back to defaults.

### Changes

- Added `ValidFormats` and `ValidCatalogs` exported maps in `pkg/generator`
- Added `Validate() error` method on `*Options` that checks the output format, catalog value, and that `Catalog` and `CatalogFile` are not both set
- `cmd/generate.go` now calls `opts.Validate()` instead of its own inline checks
- Added `TestOptionsValidate` table-driven tests in `pkg/generator`
- Added `TestRunGenerateRejectsInvalidFormat` and `TestRunGenerateRejectsInvalidCatalog` in `cmd`

### Why explicit Validate() and not auto-validation in New()

Calling `Validate()` inside `New()` would require callers to handle errors from a constructor, which is awkward in Go. An explicit `Validate()` lets library callers run it before `New()` and handle the error cleanly.

### Testing

All existing tests pass with no changes to their behaviour.
```
ok  github.com/sbomit/sbomit/cmd          1.395s
ok  github.com/sbomit/sbomit/pkg/generator  0.010s
ok  github.com/sbomit/sbomit/pkg/resolver   0.004s
```