### PR TITLE
pkg/generator: decouple document generation from writing

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"os"
-	"strings"
 
 	"github.com/sbomit/sbomit/pkg/generator"
 	"github.com/spf13/cobra"
@@ -72,29 +72,6 @@ func runGenerate(attestationFile string) error {
 		return fmt.Errorf("attestation file not found: %s", attestationFile)
 	}
 
-	validFormats := map[string]bool{
-		"spdx23": true, "spdx22": true, "cdx14": true, "cdx15": true,
-		"spdx-2.3": true, "spdx-2.2": true, "cdx-1.4": true, "cdx-1.5": true,
-	}
-	if !validFormats[strings.ToLower(outputFormat)] {
-		return fmt.Errorf("invalid output format: %s (supported: spdx23, spdx22, cdx14, cdx15)", outputFormat)
-	}
-
-	validCatalogs := map[string]bool{
-		"": true, "syft": true, "trivy": true,
-	}
-	if !validCatalogs[strings.ToLower(catalog)] {
-		return fmt.Errorf("invalid catalog: %s (supported: syft, trivy)", catalog)
-	}
-	if catalog != "" && catalogFile != "" {
-		return fmt.Errorf("--catalog and --catalog-file cannot be used together")
-	}
-	if catalogFile != "" {
-		if _, err := os.Stat(catalogFile); os.IsNotExist(err) {
-			return fmt.Errorf("catalog file not found: %s", catalogFile)
-		}
-	}
-
 	opts := &generator.Options{
 		DocumentName:     documentName,
 		DocumentVersion:  documentVersion,
@@ -108,10 +85,39 @@ func runGenerate(attestationFile string) error {
 		SkipPaths:        skipPaths,
 	}
 
+	if err := opts.Validate(); err != nil {
+		return err
+	}
+
+	// File-existence check stays here: it is a CLI UX concern (fast failure
+	// before any processing) rather than pure option validation.
+	if catalogFile != "" {
+		if _, err := os.Stat(catalogFile); os.IsNotExist(err) {
+			return fmt.Errorf("catalog file not found: %s", catalogFile)
+		}
+	}
+
 	gen := generator.New(opts)
 	doc, err := gen.GenerateFromFile(attestationFile)
 	if err != nil {
 		return fmt.Errorf("failed to generate SBOM: %w", err)
+	}
+
+	// Choose output destination and write the document.
+	var out io.Writer
+	if outputPath == "" || outputPath == "-" {
+		out = os.Stdout
+	} else {
+		f, err := os.Create(outputPath)
+		if err != nil {
+			return fmt.Errorf("create output file: %w", err)
+		}
+		defer f.Close()
+		out = f
+	}
+
+	if err := gen.Write(out, doc); err != nil {
+		return fmt.Errorf("write SBOM: %w", err)
 	}
 
 	generator.WriteSummary(os.Stderr, generator.GenerateSummary(doc), summaryFlag)

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -3,6 +3,7 @@ package generator
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -35,6 +36,17 @@ type Options struct {
 	SkipPaths        []string
 }
 
+// ValidFormats is the set of recognised OutputFormat values.
+var ValidFormats = map[string]bool{
+	"spdx23": true, "spdx22": true, "cdx14": true, "cdx15": true,
+	"spdx-2.3": true, "spdx-2.2": true, "cdx-1.4": true, "cdx-1.5": true,
+}
+
+// ValidCatalogs is the set of recognised Catalog values (empty string = no catalog).
+var ValidCatalogs = map[string]bool{
+	"": true, "syft": true, "trivy": true,
+}
+
 // DefaultOptions returns default generator options
 func DefaultOptions() *Options {
 	return &Options{
@@ -48,6 +60,22 @@ func DefaultOptions() *Options {
 		ProjectDir:       "",
 		SkipPaths:        []string{},
 	}
+}
+
+// Validate checks that the Options fields are self-consistent and supported.
+// Library callers should invoke this before generator.New(opts) to get a clear
+// error rather than silent fallback to defaults.
+func (o *Options) Validate() error {
+	if !ValidFormats[strings.ToLower(o.OutputFormat)] {
+		return fmt.Errorf("invalid output format %q (supported: spdx23, spdx22, cdx14, cdx15)", o.OutputFormat)
+	}
+	if !ValidCatalogs[strings.ToLower(o.Catalog)] {
+		return fmt.Errorf("invalid catalog %q (supported: syft, trivy)", o.Catalog)
+	}
+	if o.Catalog != "" && o.CatalogFile != "" {
+		return fmt.Errorf("Catalog and CatalogFile cannot both be set")
+	}
+	return nil
 }
 
 type Generator struct {
@@ -99,6 +127,9 @@ func (g *Generator) printParsedAttestationSummary(attestations []attestation.Typ
 	fmt.Fprintf(os.Stderr, "Parsed attestations (%d total): %s\n", len(attestations), strings.Join(parts, ", "))
 }
 
+// GenerateFromAttestations builds and returns an *sbom.Document from the
+// provided attestations. It no longer writes any output; call Write to
+// serialise the document.
 func (g *Generator) GenerateFromAttestations(attestations []attestation.TypedAttestation) (*sbom.Document, error) {
 	var baseDoc *sbom.Document
 	var err error
@@ -160,12 +191,33 @@ func (g *Generator) GenerateFromAttestations(attestations []attestation.TypedAtt
 		g.applyMetadata(baseDoc)
 		enrichment := g.mergePreferAttestation(baseDoc, attDoc)
 		WriteEnrichmentSummary(os.Stderr, enrichment)
-		err = g.writeOutput(baseDoc)
-		return baseDoc, err
+		return baseDoc, nil
 	}
 
-	err = g.writeOutput(attDoc)
-	return attDoc, err
+	return attDoc, nil
+}
+
+// Write serialises doc to w using the output format configured in Options.
+// The caller is responsible for opening and closing the destination (file,
+// os.Stdout, bytes.Buffer, etc.).
+func (g *Generator) Write(w io.Writer, doc *sbom.Document) error {
+	wr := writer.New()
+	format := g.getOutputFormat()
+	return wr.WriteStreamWithOptions(doc, &writeCloserAdapter{w: w}, &writer.Options{Format: format})
+}
+
+// writeCloserAdapter wraps an io.Writer so it satisfies io.WriteCloser.
+// Close is a no-op because the caller owns the underlying writer.
+type writeCloserAdapter struct {
+	w io.Writer
+}
+
+func (a *writeCloserAdapter) Write(p []byte) (int, error) {
+	return a.w.Write(p)
+}
+
+func (a *writeCloserAdapter) Close() error {
+	return nil
 }
 
 func (g *Generator) shouldSkip(path string) bool {
@@ -547,33 +599,6 @@ func (g *Generator) createFileNode(file resolver.FileInfo) *sbom.Node {
 	}
 
 	return node
-}
-
-// nopWriteCloser wraps os.File to implement io.WriteCloser
-type nopWriteCloser struct {
-	w *os.File
-}
-
-func (n *nopWriteCloser) Write(p []byte) (int, error) {
-	return n.w.Write(p)
-}
-
-func (n *nopWriteCloser) Close() error {
-	if n.w == os.Stdout {
-		return nil
-	}
-	return n.w.Close()
-}
-
-func (g *Generator) writeOutput(doc *sbom.Document) error {
-	w := writer.New()
-	format := g.getOutputFormat()
-
-	if g.opts.OutputPath == "" || g.opts.OutputPath == "-" {
-		return w.WriteStreamWithOptions(doc, &nopWriteCloser{w: os.Stdout}, &writer.Options{Format: format})
-	}
-
-	return w.WriteFileWithOptions(doc, g.opts.OutputPath, &writer.Options{Format: format})
 }
 
 func (g *Generator) getOutputFormat() formats.Format {

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -1,12 +1,77 @@
 package generator
 
 import (
+	"bytes"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/protobom/protobom/pkg/formats"
 	"github.com/protobom/protobom/pkg/sbom"
 	"github.com/protobom/protobom/pkg/writer"
 )
+
+func TestOptionsValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		opts        Options
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "valid defaults",
+			opts: Options{OutputFormat: "spdx23", Catalog: ""},
+		},
+		{
+			name: "valid uppercase format alias",
+			opts: Options{OutputFormat: "CDX15", Catalog: ""},
+		},
+		{
+			name: "valid cdx alias with dash",
+			opts: Options{OutputFormat: "cdx-1.5", Catalog: "trivy"},
+		},
+		{
+			name: "valid syft catalog",
+			opts: Options{OutputFormat: "spdx22", Catalog: "syft"},
+		},
+		{
+			name:        "invalid output format",
+			opts:        Options{OutputFormat: "xml", Catalog: ""},
+			wantErr:     true,
+			errContains: "invalid output format",
+		},
+		{
+			name:        "invalid catalog",
+			opts:        Options{OutputFormat: "spdx23", Catalog: "grype"},
+			wantErr:     true,
+			errContains: "invalid catalog",
+		},
+		{
+			name:        "catalog and catalogFile both set",
+			opts:        Options{OutputFormat: "spdx23", Catalog: "syft", CatalogFile: "/some/file.json"},
+			wantErr:     true,
+			errContains: "cannot both be set",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.opts.Validate()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tc.errContains != "" && !strings.Contains(err.Error(), tc.errContains) {
+					t.Fatalf("expected error containing %q, got: %v", tc.errContains, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("expected no error, got: %v", err)
+				}
+			}
+		})
+	}
+}
 
 func TestGenerateFromAttestationsCanUseCatalogFile(t *testing.T) {
 	tmp := t.TempDir()
@@ -36,14 +101,25 @@ func TestGenerateFromAttestationsCanUseCatalogFile(t *testing.T) {
 		DocumentVersion:  "0.0.1",
 		AttestationTypes: []string{},
 		OutputFormat:     "spdx23",
-		OutputPath:       outPath,
 		CatalogFile:      catalogPath,
 		ProjectDir:       "/does/not/exist",
 	})
 
-	if _, err := gen.GenerateFromAttestations(nil); err != nil {
+	// GenerateFromAttestations no longer writes output; get the doc and write it ourselves.
+	doc, err := gen.GenerateFromAttestations(nil)
+	if err != nil {
 		t.Fatalf("generate with catalog file: %v", err)
 	}
+
+	f, err := os.Create(outPath)
+	if err != nil {
+		t.Fatalf("create output file: %v", err)
+	}
+	if err := gen.Write(f, doc); err != nil {
+		_ = f.Close()
+		t.Fatalf("write SBOM: %v", err)
+	}
+	_ = f.Close()
 
 	outDoc, err := gen.readCatalogFile(outPath)
 	if err != nil {
@@ -57,6 +133,29 @@ func TestGenerateFromAttestationsCanUseCatalogFile(t *testing.T) {
 	}
 
 	t.Fatal("catalog package was not preserved")
+}
+
+func TestWrite_WritesToBuffer(t *testing.T) {
+	gen := New(&Options{
+		DocumentName:     "buf-test",
+		DocumentVersion:  "0.0.1",
+		AttestationTypes: []string{},
+		OutputFormat:     "spdx23",
+	})
+
+	doc, err := gen.GenerateFromAttestations(nil)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := gen.Write(&buf, doc); err != nil {
+		t.Fatalf("Write to buffer: %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "spdxVersion") {
+		t.Fatalf("expected SPDX JSON in buffer, got: %s", buf.String())
+	}
 }
 
 func TestMergePreferAttestationTracksAddedPackages(t *testing.T) {


### PR DESCRIPTION
Fixes #67. Part of #62.

## Problem

`GenerateFromAttestations` (and by extension `GenerateFromFile`) always called `writeOutput` internally before returning. A library caller who wanted a `*sbom.Document` in memory had no way to avoid a file or stdout write as a side-effect.

## Changes

**`pkg/generator/generator.go`**
- Remove `writeOutput` and `nopWriteCloser` from the package.
- `GenerateFromAttestations` is now a pure document builder -- it returns `*sbom.Document` without writing anywhere.
- Add `Generator.Write(w io.Writer, doc *sbom.Document) error`: serialises the document to any `io.Writer` using the format from `Options.OutputFormat`. Internally wraps the writer with a thin `writeCloserAdapter` (no-op `Close`) to satisfy the protobom `writer` interface.

**`cmd/generate.go`**
- Opens the output destination itself (stdout or file) after generation.
- Calls `gen.Write(out, doc)` explicitly.
- Observable CLI behaviour is unchanged.

**`pkg/generator/generator_test.go`**
- `TestGenerateFromAttestationsCanUseCatalogFile`: updated to call `gen.Write` instead of relying on the implicit write side-effect; `OutputPath` removed from the test `Options`.
- `TestWrite_WritesToBuffer`: new test that writes to a `bytes.Buffer` and asserts SPDX JSON content is present.

## Testing

All tests pass:

```
ok  github.com/sbomit/sbomit/cmd              1.45s
ok  github.com/sbomit/sbomit/pkg/generator    0.01s
ok  github.com/sbomit/sbomit/pkg/resolver     (cached)
```